### PR TITLE
Enable Yandex Open Auth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -202,7 +202,7 @@ func (s *Service) AddProvider(name string, cid string, csecret string) {
 	case "facebook":
 		s.providers = append(s.providers, provider.NewService(provider.NewFacebook(p)))
 	case "yandex":
-		s.providers = append(s.providers, provider.NewService(provider.NewFacebook(p)))
+		s.providers = append(s.providers, provider.NewService(provider.NewYandex(p)))
 	case "dev":
 		s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))
 	default:


### PR DESCRIPTION
Right now Yandex Open Auth can not be enabled, due to the fact that it is replaced with the `NewFacebook` Open Auth instance. I thought this wasn't intentional because `NewYandex` struct exists in a corresponding source file.

Yet again I wasn't able to provide additional test-cases. But I ran existing tests (with exception of coveralls) successfully.