### PR TITLE
Remove replace module from go.mod

### DIFF
--- a/_example/backend/go.mod
+++ b/_example/backend/go.mod
@@ -11,4 +11,3 @@ require (
 	golang.org/x/sys v0.0.0-20190116161447-11f53e031339 // indirect
 )
 
-replace github.com/go-pkgz/auth => ../../


### PR DESCRIPTION
Update go.mod file to fix error during building container
```
➜  _example git:(master) docker-compose up --build 
Building auth-example
Step 1/12 : FROM umputun/baseimage:buildgo-latest as build-backend
 ---> 859313c20f9b
Step 2/12 : COPY backend /src/backend
 ---> Using cache
 ---> bc345bac96b8
Step 3/12 : WORKDIR /src/backend
 ---> Using cache
 ---> c389827d5e10
Step 4/12 : RUN go get && go get -u github.com/go-pkgz/auth
 ---> Running in 89dc3de4efa3
go: parsing /go.mod: open /go.mod: no such file or directory
go: finding github.com/go-pkgz/mongo v1.1.0
go: finding github.com/go-chi/chi v3.3.3+incompatible
go: finding github.com/go-pkgz/rest v1.2.0
go: finding github.com/go-pkgz/lgr v0.2.2
go: finding golang.org/x/net v0.0.0-20190110200230-915654e7eabc
go: finding golang.org/x/sys v0.0.0-20190116161447-11f53e031339
go: finding golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
go: error loading module requirements
ERROR: Service 'auth-example' failed to build: The command '/bin/sh -c go get && go get -u github.com/go-pkgz/auth' returned a non-zero code: 1

```