### PR TITLE
Simplify claims validation

### DIFF
--- a/token/jwt.go
+++ b/token/jwt.go
@@ -159,20 +159,12 @@ func (j *Service) Parse(tokenString string) (Claims, error) {
 	return *claims, j.validate(claims)
 }
 
+// allow expired token
 func (j *Service) validate(claims *Claims) error {
-	cerr := claims.Valid()
+	c := *claims // shallow copy
+	c.ExpiresAt = 0
 
-	if cerr == nil {
-		return nil
-	}
-
-	if e, ok := cerr.(*jwt.ValidationError); ok {
-		e.Errors ^= jwt.ValidationErrorExpired // clear ValidationErrorExpired, allow expired token
-		if e.Errors != 0 {
-			return e
-		}
-	}
-	return nil
+	return c.Valid()
 }
 
 // Set creates token cookie with xsrf cookie and put it to ResponseWriter


### PR DESCRIPTION
I have simplified claims validation a bit.

Note also that in the current version of the code this line:
https://github.com/go-pkgz/auth/blob/f3439d6075ac8d5bb6658cc71eb70edd86758336/token/jwt.go#L170
adds `jwt.ValidationErrorExpired` flag if it is not present.

PS
Why expired tokens are allowed?
