### PR TITLE
Claims validation - preserve orginal error

### DIFF
--- a/token/jwt.go
+++ b/token/jwt.go
@@ -167,12 +167,12 @@ func (j *Service) validate(claims *Claims) error {
 	}
 
 	if e, ok := cerr.(*jwt.ValidationError); ok {
-		e.Errors ^= jwt.ValidationErrorExpired // clear ValidationErrorExpired, allow expired token
-		if e.Errors != 0 {
-			return cerr
+		if e.Errors == jwt.ValidationErrorExpired {
+			return nil // allow expired tokens
 		}
 	}
-	return nil
+
+	return cerr
 }
 
 // Set creates token cookie with xsrf cookie and put it to ResponseWriter


### PR DESCRIPTION
The latest [commit](https://github.com/go-pkgz/auth/commit/2db2238aa8ff296a23d29eb300955bdb866bbd32) effectively does nothing because `e` is a pointer.
