### PR TITLE
Proposed changes to address: /auth prefix hardcoded in providers

### DIFF
--- a/provider/dev_provider.go
+++ b/provider/dev_provider.go
@@ -36,7 +36,7 @@ type DevAuthServer struct {
 // Run oauth2 dev server on port devAuthPort
 func (d *DevAuthServer) Run(ctx context.Context) {
 	d.username = "dev_user"
-	d.Logf("[INFO] run local oauth2 dev server on %d, redir url=%s", devAuthPort, d.Provider.redirectURL)
+	d.Logf("[INFO] run local oauth2 dev server on %d, redir url=%s", devAuthPort, d.Provider.conf.RedirectURL)
 	d.lock.Lock()
 	var err error
 
@@ -70,7 +70,7 @@ func (d *DevAuthServer) Run(ctx context.Context) {
 				}
 
 				state := r.URL.Query().Get("state")
-				callbackURL := fmt.Sprintf("%s?code=g0ZGZmNjVmOWI&state=%s", d.Provider.redirectURL, state)
+				callbackURL := fmt.Sprintf("%s?code=g0ZGZmNjVmOWI&state=%s", d.Provider.conf.RedirectURL, state)
 				d.Logf("[DEBUG] callback url=%s", callbackURL)
 				w.Header().Add("Location", callbackURL)
 				w.WriteHeader(http.StatusFound)
@@ -150,15 +150,14 @@ func (d *DevAuthServer) Shutdown() {
 
 // NewDev makes dev oauth2 provider for admin user
 func NewDev(p Params) Oauth2Handler {
-	return initOauth2Handler(p, Oauth2Handler{
+	oh := initOauth2Handler(p, Oauth2Handler{
 		name: "dev",
 		endpoint: oauth2.Endpoint{
 			AuthURL:  fmt.Sprintf("http://127.0.0.1:%d/login/oauth/authorize", devAuthPort),
 			TokenURL: fmt.Sprintf("http://127.0.0.1:%d/login/oauth/access_token", devAuthPort),
 		},
-		redirectURL: p.URL + "/auth/dev/callback",
-		scopes:      []string{"user:email"},
-		infoURL:     fmt.Sprintf("http://127.0.0.1:%d/user", devAuthPort),
+		scopes:  []string{"user:email"},
+		infoURL: fmt.Sprintf("http://127.0.0.1:%d/user", devAuthPort),
 		mapUser: func(data userData, _ []byte) token.User {
 			userInfo := token.User{
 				ID:      data.value("id"),
@@ -168,6 +167,9 @@ func NewDev(p Params) Oauth2Handler {
 			return userInfo
 		},
 	})
+
+	oh.conf.RedirectURL = p.URL + "/auth/dev/callback"
+	return oh
 }
 
 var devUserFormTmpl = `

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -21,13 +21,12 @@ type Oauth2Handler struct {
 	Params
 
 	// all of these fields specific to particular oauth2 provider
-	name        string
-	redirectURL string
-	infoURL     string
-	endpoint    oauth2.Endpoint
-	scopes      []string
-	mapUser     func(userData, []byte) token.User // map info from InfoURL to User
-	conf        oauth2.Config
+	name     string
+	infoURL  string
+	endpoint oauth2.Endpoint
+	scopes   []string
+	mapUser  func(userData, []byte) token.User // map info from InfoURL to User
+	conf     oauth2.Config
 }
 
 // Params to make initialized and ready to use provider
@@ -61,13 +60,12 @@ func initOauth2Handler(p Params, service Oauth2Handler) Oauth2Handler {
 	service.conf = oauth2.Config{
 		ClientID:     service.Cid,
 		ClientSecret: service.Csecret,
-		RedirectURL:  service.redirectURL,
 		Scopes:       service.scopes,
 		Endpoint:     service.endpoint,
 	}
 
 	p.Logf("[DEBUG] created %s oauth2, id=%s, redir=%s, endpoint=%s",
-		service.name, service.Cid, service.endpoint, service.redirectURL)
+		service.name, service.Cid, service.endpoint)
 	return service
 }
 

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -108,7 +109,10 @@ func (p Oauth2Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p.conf.RedirectURL = p.URL + r.URL.Path + urlCallbackSuffix
+	elems := strings.Split(r.URL.Path, "/")
+	path := strings.Join(elems[:len(elems)-1], "/")
+
+	p.conf.RedirectURL = strings.TrimRight(p.URL, "/") + strings.TrimRight(path, "/") + urlCallbackSuffix
 
 	// return login url
 	loginURL := p.conf.AuthCodeURL(state)

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -110,6 +110,8 @@ func (p Oauth2Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	p.conf.RedirectURL = p.URL + r.URL.Path + urlCallbackSuffix
+
 	// return login url
 	loginURL := p.conf.AuthCodeURL(state)
 	p.Logf("[DEBUG] login url %s, claims=%+v", loginURL, claims)

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -109,10 +109,9 @@ func (p Oauth2Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	elems := strings.Split(r.URL.Path, "/")
-	path := strings.Join(elems[:len(elems)-1], "/")
-
-	p.conf.RedirectURL = strings.TrimRight(p.URL, "/") + strings.TrimRight(path, "/") + urlCallbackSuffix
+	// setting RedirectURL to rootURL/routingPath/provider/callback
+	// e.g. http://localhost:8080/auth/github/callback
+	p.conf.RedirectURL = p.makeRedirURL(r.URL.Path)
 
 	// return login url
 	loginURL := p.conf.AuthCodeURL(state)
@@ -218,4 +217,11 @@ func (p Oauth2Handler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p.JwtService.Reset(w)
+}
+
+func (p Oauth2Handler) makeRedirURL(path string) string {
+	elems := strings.Split(path, "/")
+	newPath := strings.Join(elems[:len(elems)-1], "/")
+
+	return strings.TrimRight(p.URL, "/") + strings.TrimRight(newPath, "/") + urlCallbackSuffix
 }

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -66,7 +66,7 @@ func initOauth2Handler(p Params, service Oauth2Handler) Oauth2Handler {
 	}
 
 	p.Logf("[DEBUG] created %s oauth2, id=%s, redir=%s, endpoint=%s",
-		service.name, service.Cid, service.endpoint)
+		service.name, service.Cid, service.makeRedirURL("/YOUR_ROUTE/"+service.name+"/"), service.endpoint)
 	return service
 }
 

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -143,11 +143,10 @@ func TestOauth2Logout(t *testing.T) {
 
 func TestOauth2InitProvider(t *testing.T) {
 	params := Params{URL: "url", Cid: "cid", Csecret: "csecret", Issuer: "app-test"}
-	provider := Oauth2Handler{name: "test", redirectURL: "redir"}
+	provider := Oauth2Handler{name: "test"}
 	res := initOauth2Handler(params, provider)
 	assert.Equal(t, "cid", res.conf.ClientID)
 	assert.Equal(t, "csecret", res.conf.ClientSecret)
-	assert.Equal(t, "redir", res.redirectURL)
 	assert.Equal(t, "test", res.name)
 	assert.Equal(t, "app-test", res.Issuer)
 }
@@ -174,9 +173,8 @@ func prepOauth2Test(t *testing.T, loginPort, authPort int) func() {
 			AuthURL:  fmt.Sprintf("http://localhost:%d/login/oauth/authorize", authPort),
 			TokenURL: fmt.Sprintf("http://localhost:%d/login/oauth/access_token", authPort),
 		},
-		redirectURL: fmt.Sprintf("http://localhost:%d/callback", loginPort),
-		scopes:      []string{"user:email"},
-		infoURL:     fmt.Sprintf("http://localhost:%d/user", authPort),
+		scopes:  []string{"user:email"},
+		infoURL: fmt.Sprintf("http://localhost:%d/user", authPort),
 		mapUser: func(data userData, _ []byte) token.User {
 			userInfo := token.User{
 				ID:      "mock_" + data.value("id"),

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -165,6 +165,23 @@ func TestOauth2InvalidHandler(t *testing.T) {
 	assert.Equal(t, 405, resp.StatusCode)
 }
 
+func TestMakeRedirURL(t *testing.T) {
+	cases := []struct{ rootURL, route, out string }{
+		{"localhost:8080/", "/my/auth/path/google", "localhost:8080/my/auth/path/callback"},
+		{"localhost:8080", "/auth/google", "localhost:8080/auth/callback"},
+		{"localhost:8080/", "/auth/google", "localhost:8080/auth/callback"},
+		{"localhost:8080", "/", "localhost:8080/callback"},
+		{"localhost:8080/", "/", "localhost:8080/callback"},
+		{"mysite.com", "", "mysite.com/callback"},
+	}
+
+	for i := range cases {
+		c := cases[i]
+		oh := initOauth2Handler(Params{URL: c.rootURL}, Oauth2Handler{})
+		assert.Equal(t, c.out, oh.makeRedirURL(c.route))
+	}
+}
+
 func prepOauth2Test(t *testing.T, loginPort, authPort int) func() {
 
 	provider := Oauth2Handler{

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -16,11 +16,10 @@ import (
 // NewGoogle makes google oauth2 provider
 func NewGoogle(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
-		name:        "google",
-		endpoint:    google.Endpoint,
-		redirectURL: p.URL + "/auth/google/callback",
-		scopes:      []string{"https://www.googleapis.com/auth/userinfo.profile"},
-		infoURL:     "https://www.googleapis.com/oauth2/v3/userinfo",
+		name:     "google",
+		endpoint: google.Endpoint,
+		scopes:   []string{"https://www.googleapis.com/auth/userinfo.profile"},
+		infoURL:  "https://www.googleapis.com/oauth2/v3/userinfo",
 		mapUser: func(data userData, _ []byte) token.User {
 			userInfo := token.User{
 				// encode email with provider name to avoid collision if same id returned by other provider
@@ -39,11 +38,10 @@ func NewGoogle(p Params) Oauth2Handler {
 // NewGithub makes github oauth2 provider
 func NewGithub(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
-		name:        "github",
-		endpoint:    github.Endpoint,
-		redirectURL: p.URL + "/auth/github/callback",
-		scopes:      []string{},
-		infoURL:     "https://api.github.com/user",
+		name:     "github",
+		endpoint: github.Endpoint,
+		scopes:   []string{},
+		infoURL:  "https://api.github.com/user",
 		mapUser: func(data userData, _ []byte) token.User {
 			userInfo := token.User{
 				ID:      "github_" + token.HashID(sha1.New(), data.value("login")),
@@ -74,11 +72,10 @@ func NewFacebook(p Params) Oauth2Handler {
 	}
 
 	return initOauth2Handler(p, Oauth2Handler{
-		name:        "facebook",
-		endpoint:    facebook.Endpoint,
-		redirectURL: p.URL + "/auth/facebook/callback",
-		scopes:      []string{"public_profile"},
-		infoURL:     "https://graph.facebook.com/me?fields=id,name,picture",
+		name:     "facebook",
+		endpoint: facebook.Endpoint,
+		scopes:   []string{"public_profile"},
+		infoURL:  "https://graph.facebook.com/me?fields=id,name,picture",
 		mapUser: func(data userData, bdata []byte) token.User {
 			userInfo := token.User{
 				ID:   "facebook_" + token.HashID(sha1.New(), data.value("id")),
@@ -100,10 +97,9 @@ func NewFacebook(p Params) Oauth2Handler {
 // NewYandex makes yandex oauth2 provider
 func NewYandex(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
-		name:        "yandex",
-		endpoint:    yandex.Endpoint,
-		redirectURL: p.URL + "/auth/yandex/callback",
-		scopes:      []string{},
+		name:     "yandex",
+		endpoint: yandex.Endpoint,
+		scopes:   []string{},
 		// See https://tech.yandex.com/passport/doc/dg/reference/response-docpage/
 		infoURL: "https://login.yandex.ru/info?format=json",
 		mapUser: func(data userData, _ []byte) token.User {

--- a/provider/service.go
+++ b/provider/service.go
@@ -64,7 +64,7 @@ func (p Service) Handler(w http.ResponseWriter, r *http.Request) {
 		p.AuthHandler(w, r)
 		return
 	}
-	if strings.HasSuffix(r.URL.Path, urlCallbackSuffix) {
+	if strings.HasSuffix(r.URL.Path, urlLogoutSuffix) {
 		p.LogoutHandler(w, r)
 		return
 	}

--- a/provider/service.go
+++ b/provider/service.go
@@ -12,6 +12,12 @@ import (
 	"github.com/go-pkgz/auth/token"
 )
 
+const (
+	urlLoginSuffix    = "/login"
+	urlCallbackSuffix = "/callback"
+	urlLogoutSuffix   = "/logout"
+)
+
 // Service represents oauth2 provider. Adds Handler method multiplexing login, auth and logout requests
 type Service struct {
 	Provider
@@ -50,15 +56,15 @@ func (p Service) Handler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	if strings.HasSuffix(r.URL.Path, "/login") {
+	if strings.HasSuffix(r.URL.Path, urlLoginSuffix) {
 		p.LoginHandler(w, r)
 		return
 	}
-	if strings.HasSuffix(r.URL.Path, "/callback") {
+	if strings.HasSuffix(r.URL.Path, urlCallbackSuffix) {
 		p.AuthHandler(w, r)
 		return
 	}
-	if strings.HasSuffix(r.URL.Path, "/logout") {
+	if strings.HasSuffix(r.URL.Path, urlCallbackSuffix) {
 		p.LogoutHandler(w, r)
 		return
 	}


### PR DESCRIPTION
To resolve #7 

login/logout/callback url is always formed (and hardcoded) as:
ROOT_URL/{router path}/PROVIDER/{login | callback | logout}

Would it make sense to define redirect URL in Oauth2Handler Login method in runtime as:
p.conf.RedirectURL = p.URL + r.URL.Path + "/callback" ?