### PR TITLE
add support of aud specific secret

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -67,6 +67,13 @@ func main() {
 		}),
 		Logger:      log.Default(), // optional logger for auth library
 		UseGravatar: true,          // for verified provider use gravatar service
+		AudienceReader: token.AudienceFunc(func() (map[string]string, error) {
+			return map[string]string{
+				"admins":     "admins-secret",
+				"powerusers": "pu-secret",
+				"users":      "users",
+			}, nil
+		}),
 	}
 
 	// create auth service

--- a/auth.go
+++ b/auth.go
@@ -47,6 +47,7 @@ type Opts struct {
 	DisableIAT  bool // disable IssuedAt claim
 
 	// optional (custom) names for cookies and headers
+	AudCookieName  string // default "AUD-TOKEN"
 	JWTCookieName  string // default "JWT"
 	JWTHeaderKey   string // default "X-JWT"
 	XSRFCookieName string // default "XSRF-TOKEN"
@@ -100,6 +101,7 @@ func NewService(opts Opts) (res *Service) {
 		CookieDuration: opts.CookieDuration,
 		DisableXSRF:    opts.DisableXSRF,
 		DisableIAT:     opts.DisableIAT,
+		AudCookieName:  opts.AudCookieName,
 		JWTCookieName:  opts.JWTCookieName,
 		JWTHeaderKey:   opts.JWTHeaderKey,
 		XSRFCookieName: opts.XSRFCookieName,

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -32,7 +32,7 @@ type RefreshCache interface {
 
 // TokenService defines interface accessing tokens
 type TokenService interface {
-	Parse(tokenString string) (claims token.Claims, err error)
+	Parse(tokenString, aud string) (claims token.Claims, err error)
 	Set(w http.ResponseWriter, claims token.Claims) (token.Claims, error)
 	Get(r *http.Request) (claims token.Claims, token string, err error)
 	IsExpired(claims token.Claims) bool

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -125,7 +125,7 @@ func TestAuthJWTRefresh(t *testing.T) {
 	t.Log(resp.Cookies()[0].Value)
 	assert.True(t, resp.Cookies()[0].Value != testJwtExpired, "jwt token changed")
 
-	claims, err := a.JWTService.Parse(resp.Cookies()[0].Value)
+	claims, err := a.JWTService.Parse(resp.Cookies()[0].Value, "")
 	assert.NoError(t, err)
 	ts := time.Unix(claims.ExpiresAt, 0)
 	assert.True(t, ts.After(time.Now()), "expiration in the future")
@@ -170,7 +170,7 @@ func TestAuthJWTRefreshConcurrentWithCache(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&refreshCount), "should make one refresh only")
 
 	// make another expired token
-	c, err := a.JWTService.Parse(testJwtExpired)
+	c, err := a.JWTService.Parse(testJwtExpired, "")
 	require.NoError(t, err)
 	c.User.ID = "other ID"
 	tkSvc := a.JWTService.(*token.Service)

--- a/provider/custom_server_test.go
+++ b/provider/custom_server_test.go
@@ -83,7 +83,7 @@ func TestCustomProvider(t *testing.T) {
 			assert.Equal(t, "XSRF-TOKEN", resp.Cookies()[1].Name)
 			assert.NotEqual(t, "", resp.Cookies()[1].Value, "xsrf cookie set")
 
-			claims, err := params.JwtService.Parse(resp.Cookies()[0].Value)
+			claims, err := params.JwtService.Parse(resp.Cookies()[0].Value, "")
 			assert.Nil(t, err)
 
 			assert.Equal(t, token.User{Name: "admin", ID: "admin",

--- a/provider/dev_provider_test.go
+++ b/provider/dev_provider_test.go
@@ -62,7 +62,7 @@ func TestDevProvider(t *testing.T) {
 	assert.Equal(t, "XSRF-TOKEN", resp.Cookies()[1].Name)
 	assert.NotEqual(t, "", resp.Cookies()[1].Value, "xsrf cookie set")
 
-	claims, err := params.JwtService.Parse(resp.Cookies()[0].Value)
+	claims, err := params.JwtService.Parse(resp.Cookies()[0].Value, "")
 	assert.Nil(t, err)
 
 	assert.Equal(t, token.User{Name: "dev_user", ID: "dev_user",

--- a/provider/direct_test.go
+++ b/provider/direct_test.go
@@ -40,7 +40,7 @@ func TestDirect_LoginHandler(t *testing.T) {
 	request := &http.Request{Header: http.Header{"Cookie": rr.Header()["Set-Cookie"]}}
 	c, err := request.Cookie("JWT")
 	require.NoError(t, err)
-	claims, err := d.TokenService.Parse(c.Value)
+	claims, err := d.TokenService.Parse(c.Value, "")
 	require.NoError(t, err)
 	t.Logf("%+v", claims)
 	assert.Equal(t, "xyz123", claims.Audience)

--- a/provider/oauth1_test.go
+++ b/provider/oauth1_test.go
@@ -57,7 +57,7 @@ func TestOauth1Login(t *testing.T) {
 	jwtSvc := token.NewService(token.Opts{SecretReader: token.SecretFunc(mockKeyStore), SecureCookies: false,
 		TokenDuration: time.Hour, CookieDuration: days31})
 
-	claims, err := jwtSvc.Parse(tk)
+	claims, err := jwtSvc.Parse(tk, "")
 	require.NoError(t, err)
 	t.Log(claims)
 	assert.Equal(t, "remark42", claims.Issuer)

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -57,7 +57,7 @@ func TestOauth2Login(t *testing.T) {
 	jwtSvc := token.NewService(token.Opts{SecretReader: token.SecretFunc(mockKeyStore), SecureCookies: false,
 		TokenDuration: time.Hour, CookieDuration: days31})
 
-	claims, err := jwtSvc.Parse(tk)
+	claims, err := jwtSvc.Parse(tk, "")
 	require.NoError(t, err)
 	t.Log(claims)
 	assert.Equal(t, "remark42", claims.Issuer)

--- a/provider/service.go
+++ b/provider/service.go
@@ -35,7 +35,7 @@ type AvatarSaver interface {
 
 // TokenService defines interface accessing tokens
 type TokenService interface {
-	Parse(tokenString string) (claims token.Claims, err error)
+	Parse(tokenString, aud string) (claims token.Claims, err error)
 	Set(w http.ResponseWriter, claims token.Claims) (token.Claims, error)
 	Get(r *http.Request) (claims token.Claims, token string, err error)
 	Reset(w http.ResponseWriter)

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -46,7 +46,7 @@ func (f SenderFunc) Send(address, text string) error {
 // VerifTokenService defines interface accessing tokens
 type VerifTokenService interface {
 	Token(claims token.Claims) (string, error)
-	Parse(tokenString string) (claims token.Claims, err error)
+	Parse(tokenString, aud string) (claims token.Claims, err error)
 	IsExpired(claims token.Claims) bool
 	Set(w http.ResponseWriter, claims token.Claims) (token.Claims, error)
 	Reset(w http.ResponseWriter)
@@ -68,7 +68,7 @@ func (e VerifyHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	// confirmation token presented
 	// GET /login?token=confirmation-jwt&sess=1
-	confClaims, err := e.TokenService.Parse(tkn)
+	confClaims, err := e.TokenService.Parse(tkn, "")
 	if err != nil {
 		rest.SendErrorJSON(w, r, e.L, http.StatusForbidden, err, "failed to verify confirmation token")
 		return

--- a/provider/verify_test.go
+++ b/provider/verify_test.go
@@ -50,7 +50,7 @@ func TestVerifyHandler_LoginSendConfirm(t *testing.T) {
 	assert.Contains(t, emailer.text, "test123 blah@user.com remark42 token:")
 
 	tknStr := strings.Split(emailer.text, " token:")[1]
-	tkn, err := e.TokenService.Parse(tknStr)
+	tkn, err := e.TokenService.Parse(tknStr, "")
 	assert.NoError(t, err)
 	t.Logf("%s %+v", tknStr, tkn)
 	assert.Equal(t, "test123::blah@user.com", tkn.Handshake.ID)
@@ -83,7 +83,7 @@ func TestVerifyHandler_LoginAcceptConfirm(t *testing.T) {
 	request := &http.Request{Header: http.Header{"Cookie": rr.Header()["Set-Cookie"]}}
 	c, err := request.Cookie("JWT")
 	require.NoError(t, err)
-	claims, err := e.TokenService.Parse(c.Value)
+	claims, err := e.TokenService.Parse(c.Value, "")
 	require.NoError(t, err)
 	t.Logf("%+v", claims)
 	assert.Equal(t, "remark42", claims.Audience)


### PR DESCRIPTION
to implement #30 

Basically I suggest to introduce a new cookie just for audience. For this cookie will be used common shared secret. After audience is obtained it is possible to use audience-specific secrets. I change implementation of `AudienceReader` to return not only an audience but a secret for it. 

Unfortunately I didn't come up with smth better than break back comparability of `Parse` method. I obviously need to know during the parsing whether common-shared-secret or  audience secret should be used. I see already one flaw with this implementation: audience secret should be provider-specific as well.

Let me know if you think that I am looking in the right direction. 