### PR TITLE
Using ConstantTimeCompare instead of regular string comparison

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -5,6 +5,7 @@
 package middleware
 
 import (
+	"crypto/subtle"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -178,7 +179,8 @@ func (a *Authenticator) basicAdminUser(r *http.Request) bool {
 		return false
 	}
 
-	if user != "admin" || passwd != a.AdminPasswd {
+	// using ConstantTimeCompare to avoid timing attack
+	if user != "admin" || subtle.ConstantTimeCompare([]byte(passwd), []byte(a.AdminPasswd)) != 1 {
 		a.Logf("[WARN] admin basic auth failed, user/passwd mismatch, %s:%s", user, passwd)
 		return false
 	}


### PR DESCRIPTION
To avoid [timing attack](https://en.wikipedia.org/wiki/Timing_attack)