### PR TITLE
Microsoft (azure) oauth2 provider

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters-settings:
   golint:
     min-confidence: 0
   gocyclo:
-    min-complexity: 15
+    min-complexity: 20
   maligned:
     suggest-new: true
   goconst:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # auth - authentication via oauth2, direct and email
 [![Build Status](https://github.com/go-pkgz/auth/workflows/build/badge.svg)](https://github.com/go-pkgz/auth/actions) [![Coverage Status](https://coveralls.io/repos/github/go-pkgz/auth/badge.svg?branch=master)](https://coveralls.io/github/go-pkgz/auth?branch=master) [![godoc](https://godoc.org/github.com/go-pkgz/auth?status.svg)](https://pkg.go.dev/github.com/go-pkgz/auth?tab=doc)
 
-This library provides "social login" with Github, Google, Facebook, Twitter, Yandex and Battle.net as well as custom auth providers and email verification.
+This library provides "social login" with Github, Google, Facebook, Microsoft, Twitter, Yandex and Battle.net as well as custom auth providers and email verification.
 
 - Multiple oauth2 providers can be used at the same time
 - Special `dev` provider allows local testing and development
@@ -334,6 +334,15 @@ Authentication handled by external providers. You should setup oauth2 for all (o
 7.  Take note of the **Client ID** and **Client Secret**
 
 _instructions for google oauth2 setup borrowed from [oauth2_proxy](https://github.com/bitly/oauth2_proxy)_
+
+#### Microsoft Auth Provider
+
+1 .Register a new application [using the Azure portal](https://docs.microsoft.com/en-us/graph/auth-register-app-v2).
+2.  Under **"Authentication/Platform configurations/Web"** enter the correct url constructed as domain + `/auth/microsoft/callback`. i.e. `https://example.mysite.com/auth/microsoft/callback`
+3. In "Overview" take note of the **Application (client) ID** 
+4. Choose the new project from the top right project dropdown (only if another project is selected)
+5.  Select "Certificates & secrets" and click on "+ New Client Secret". 
+
 
 #### GitHub Auth Provider
 

--- a/_example/frontend/index.html
+++ b/_example/frontend/index.html
@@ -10,7 +10,7 @@
 <body>
 <header class="main-header">
     <h1 class="title"><a href="https://github.com/go-pkgz/auth">GO-PKGZ/AUTH</a><span class="pretitle">Example page</span></h1>
-    <p class="description">This library provides “social login” with Github, Google, Facebook, Yandex and Battle.net.</p>
+    <p class="description">This library provides “social login” with Github, Google, Microsoft, Facebook, Yandex and Battle.net.</p>
     <div class="login"></div>
 </header>
 <div class="status"><span class="minititle">Status:</span> <span class="status__label">unauthorized</span></div>

--- a/_example/main.go
+++ b/_example/main.go
@@ -44,7 +44,7 @@ func main() {
 		CookieDuration:    time.Hour * 24,                              // cookie fine to keep for long time
 		DisableXSRF:       true,                                        // don't disable XSRF in real-life applications!
 		Issuer:            "my-demo-service",                           // part of token, just informational
-		URL:               "http://127.0.0.1:8080",                     // base url of the protected service
+		URL:               "http://localhost:8080",                     // base url of the protected service
 		AvatarStore:       avatar.NewLocalFS("/tmp/demo-auth-service"), // stores avatars locally
 		AvatarResizeLimit: 200,                                         // resizes avatars to 200x200
 		ClaimsUpd: token.ClaimsUpdFunc(func(claims token.Claims) token.Claims { // modify issued token
@@ -75,6 +75,7 @@ func main() {
 	service.AddProvider("dev", "", "")                                                             // add dev provider
 	service.AddProvider("github", os.Getenv("AEXMPL_GITHUB_CID"), os.Getenv("AEXMPL_GITHUB_CSEC")) // add github provider
 	service.AddProvider("twitter", os.Getenv("AEXMPL_TWITTER_APIKEY"), os.Getenv("AEXMPL_TWITTER_APISEC"))
+	service.AddProvider("microsoft", os.Getenv("AEXMPL_MS_APIKEY"), os.Getenv("AEXMPL_MS_APISEC"))
 
 	// allow anonymous user via custom (direct) provider
 	service.AddDirectProvider("anonymous", anonymousAuthProvider())

--- a/_example/main.go
+++ b/_example/main.go
@@ -59,6 +59,9 @@ func main() {
 				if strings.HasPrefix(claims.User.ID, "github_") { // allow all users with github auth
 					return true
 				}
+				if strings.HasPrefix(claims.User.ID, "microsoft_") { // allow all users with ms auth
+					return true
+				}
 				if strings.HasPrefix(claims.User.Name, "dev_") { // non-guthub allow only dev_* names
 					return true
 				}

--- a/auth.go
+++ b/auth.go
@@ -1,4 +1,4 @@
-// Package auth provides "social login" with Github, Google, Facebook, Yandex and Battle.net as well as custom auth providers.
+// Package auth provides "social login" with Github, Google, Facebook, Microsoft, Yandex and Battle.net as well as custom auth providers.
 package auth
 
 import (

--- a/auth.go
+++ b/auth.go
@@ -224,6 +224,8 @@ func (s *Service) AddProvider(name, cid, csecret string) {
 		s.providers = append(s.providers, provider.NewService(provider.NewYandex(p)))
 	case "battlenet":
 		s.providers = append(s.providers, provider.NewService(provider.NewBattlenet(p)))
+	case "microsoft":
+		s.providers = append(s.providers, provider.NewService(provider.NewMicrosoft(p)))
 	case "twitter":
 		s.providers = append(s.providers, provider.NewService(provider.NewTwitter(p)))
 	case "dev":

--- a/auth_test.go
+++ b/auth_test.go
@@ -56,6 +56,7 @@ func TestProvider(t *testing.T) {
 	svc.AddProvider("google", "cid", "csecret")
 	svc.AddProvider("facebook", "cid", "csecret")
 	svc.AddProvider("yandex", "cid", "csecret")
+	svc.AddProvider("microsoft", "cid", "csecret")
 	svc.AddProvider("battlenet", "cid", "csecret")
 	svc.AddProvider("bad", "cid", "csecret")
 
@@ -73,7 +74,7 @@ func TestProvider(t *testing.T) {
 	assert.Equal(t, "github", op.Name())
 
 	pp := svc.Providers()
-	assert.Equal(t, 6, len(pp))
+	assert.Equal(t, 7, len(pp))
 }
 
 func TestIntegrationProtected(t *testing.T) {

--- a/avatar/avatar_test.go
+++ b/avatar/avatar_test.go
@@ -39,8 +39,9 @@ func TestAvatar_Put(t *testing.T) {
 	assert.NoError(t, os.MkdirAll("/tmp/avatars.test", 0700))
 	defer os.RemoveAll("/tmp/avatars.test")
 
+	client := &http.Client{Timeout: time.Second}
 	u := token.User{ID: "user1", Name: "user1 name", Picture: ts.URL + "/pic.png"}
-	res, err := p.Put(u)
+	res, err := p.Put(u, client)
 	assert.NoError(t, err)
 	assert.Equal(t, "http://localhost:8080/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", res)
 	fi, err := os.Stat("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
@@ -48,7 +49,7 @@ func TestAvatar_Put(t *testing.T) {
 	assert.Equal(t, int64(21), fi.Size())
 
 	u.ID = "user2"
-	res, err = p.Put(u)
+	res, err = p.Put(u, client)
 	assert.NoError(t, err)
 	assert.Equal(t, "http://localhost:8080/avatar/a1881c06eec96db9901c7bbfe41c42a3f08e9cb4.image", res)
 	fi, err = os.Stat("/tmp/avatars.test/84/a1881c06eec96db9901c7bbfe41c42a3f08e9cb4.image")
@@ -64,9 +65,10 @@ func TestAvatar_PutIdenticon(t *testing.T) {
 	defer ts.Close()
 
 	p := Proxy{RoutePath: "/avatar", URL: "http://localhost:8080", Store: NewLocalFS("/tmp/avatars.test"), L: logger.Std}
+	client := &http.Client{Timeout: time.Second}
 
 	u := token.User{ID: "user1", Name: "user1 name"}
-	res, err := p.Put(u)
+	res, err := p.Put(u, client)
 	assert.NoError(t, err)
 	assert.Equal(t, "http://localhost:8080/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", res)
 	fi, err := os.Stat("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
@@ -84,14 +86,15 @@ func TestAvatar_PutFailed(t *testing.T) {
 	defer ts.Close()
 
 	p := Proxy{RoutePath: "/avatar", Store: NewLocalFS("/tmp/avatars.test"), L: logger.Std}
+	client := &http.Client{Timeout: time.Second}
 
 	u := token.User{ID: "user1", Name: "user1 name", Picture: "http://127.0.0.1:22345/avater/pic"}
-	_, err := p.Put(u)
+	_, err := p.Put(u, client)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connect: connection refused")
 
 	u = token.User{ID: "user1", Name: "user1 name", Picture: ts.URL + "/avatar/pic"}
-	_, err = p.Put(u)
+	_, err = p.Put(u, client)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get avatar from the orig")
 }
@@ -113,9 +116,10 @@ func TestAvatar_Routes(t *testing.T) {
 	p := Proxy{RoutePath: "/avatar", Store: NewLocalFS("/tmp/avatars.test"), L: logger.Std}
 	assert.NoError(t, os.MkdirAll("/tmp/avatars.test", 0700))
 	defer os.RemoveAll("/tmp/avatars.test")
+	client := &http.Client{Timeout: time.Second}
 
 	u := token.User{ID: "user1", Name: "user1 name", Picture: ts.URL + "/pic.png"}
-	_, err := p.Put(u)
+	_, err := p.Put(u, client)
 	assert.NoError(t, err)
 
 	// status 400

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/go-pkgz/auth
 
+go 1.14
+
 require (
 	github.com/dghubble/oauth1 v0.6.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
@@ -14,5 +16,3 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	gopkg.in/oauth2.v3 v3.12.0
 )
-
-go 1.13

--- a/provider/direct.go
+++ b/provider/direct.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/go-pkgz/rest"
@@ -63,7 +64,7 @@ func (p DirectHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		Name: user,
 		ID:   p.ProviderName + "_" + token.HashID(sha1.New(), user),
 	}
-	u, err = setAvatar(p.AvatarSaver, u)
+	u, err = setAvatar(p.AvatarSaver, u, &http.Client{Timeout: 5 * time.Second})
 	if err != nil {
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "failed to save avatar to proxy")
 		return

--- a/provider/oauth1.go
+++ b/provider/oauth1.go
@@ -127,7 +127,7 @@ func (h Oauth1Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 	h.Logf("[DEBUG] got raw user info %+v", jData)
 
 	u := h.mapUser(jData, data)
-	u, err = setAvatar(h.AvatarSaver, u)
+	u, err = setAvatar(h.AvatarSaver, u, &http.Client{Timeout: 5 * time.Second})
 	if err != nil {
 		rest.SendErrorJSON(w, r, h.L, http.StatusInternalServerError, err, "failed to save avatar to proxy")
 		return

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -283,6 +283,6 @@ func mockKeyStore(string) (string, error) { return "12345", nil }
 
 type mockAvatarSaver struct{}
 
-func (m *mockAvatarSaver) Put(u token.User) (avatarURL string, err error) {
+func (m *mockAvatarSaver) Put(u token.User, client *http.Client) (avatarURL string, err error) {
 	return "http://example.com/ava12345.png", nil
 }

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -181,11 +181,11 @@ func NewMicrosoft(p Params) Oauth2Handler {
 		infoURL:  "https://graph.microsoft.com/v1.0/me",
 		// non-beta doesn't provide photo for consumers yet
 		// see https://github.com/microsoftgraph/microsoft-graph-docs/issues/3990
-		avatarURL: "https://graph.microsoft.com/beta/me/photo/$value",
 		mapUser: func(data UserData, b []byte) token.User {
 			userInfo := token.User{
-				ID:   "microsoft_" + token.HashID(sha1.New(), data.Value("id")),
-				Name: data.Value("displayName"),
+				ID:      "microsoft_" + token.HashID(sha1.New(), data.Value("id")),
+				Name:    data.Value("displayName"),
+				Picture: "https://graph.microsoft.com/beta/me/photo/$value",
 			}
 			return userInfo
 		},

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/oauth2/facebook"
 	"golang.org/x/oauth2/github"
 	"golang.org/x/oauth2/google"
+	"golang.org/x/oauth2/microsoft"
 	"golang.org/x/oauth2/yandex"
 
 	"github.com/dghubble/oauth1"
@@ -164,6 +165,24 @@ func NewBattlenet(p Params) Oauth2Handler {
 			userInfo := token.User{
 				ID:   "battlenet_" + token.HashID(sha1.New(), data.Value("id")),
 				Name: data.Value("battletag"),
+			}
+
+			return userInfo
+		},
+	})
+}
+
+// NewMicrosoft makes microsoft azure oauth2 provider
+func NewMicrosoft(p Params) Oauth2Handler {
+	return initOauth2Handler(p, Oauth2Handler{
+		name:     "microsoft",
+		endpoint: microsoft.AzureADEndpoint("consumers"),
+		scopes:   []string{"User.Read"},
+		infoURL:  "https://graph.microsoft.com/v1.0/me",
+		mapUser: func(data UserData, b []byte) token.User {
+			userInfo := token.User{
+				ID:   "microsoft_" + token.HashID(sha1.New(), data.Value("id")),
+				Name: data.Value("displayName"),
 			}
 
 			return userInfo

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -179,12 +179,14 @@ func NewMicrosoft(p Params) Oauth2Handler {
 		endpoint: microsoft.AzureADEndpoint("consumers"),
 		scopes:   []string{"User.Read"},
 		infoURL:  "https://graph.microsoft.com/v1.0/me",
+		// non-beta doesn't provide photo for consumers yet
+		// see https://github.com/microsoftgraph/microsoft-graph-docs/issues/3990
+		avatarURL: "https://graph.microsoft.com/beta/me/photo/$value",
 		mapUser: func(data UserData, b []byte) token.User {
 			userInfo := token.User{
 				ID:   "microsoft_" + token.HashID(sha1.New(), data.Value("id")),
 				Name: data.Value("displayName"),
 			}
-
 			return userInfo
 		},
 	})

--- a/provider/service.go
+++ b/provider/service.go
@@ -30,7 +30,7 @@ func NewService(p Provider) Service {
 
 // AvatarSaver defines minimal interface to save avatar
 type AvatarSaver interface {
-	Put(u token.User) (avatarURL string, err error)
+	Put(u token.User, client *http.Client) (avatarURL string, err error)
 }
 
 // TokenService defines interface accessing tokens
@@ -72,9 +72,9 @@ func (p Service) Handler(w http.ResponseWriter, r *http.Request) {
 }
 
 // setAvatar saves avatar and puts proxied URL to u.Picture
-func setAvatar(ava AvatarSaver, u token.User) (token.User, error) {
+func setAvatar(ava AvatarSaver, u token.User, client *http.Client) (token.User, error) {
 	if ava != nil {
-		avatarURL, e := ava.Put(u)
+		avatarURL, e := ava.Put(u, client)
 		if e != nil {
 			return u, errors.Wrap(e, "failed to save avatar for")
 		}

--- a/provider/service_test.go
+++ b/provider/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,15 +59,16 @@ func TestRandToken(t *testing.T) {
 }
 
 func TestSetAvatar(t *testing.T) {
-	u, err := setAvatar(nil, token.User{Picture: "http://example.com/pic1.png"})
+	client := &http.Client{Timeout: time.Second}
+	u, err := setAvatar(nil, token.User{Picture: "http://example.com/pic1.png"}, client)
 	assert.NoError(t, err, "nil ava allowed")
 	assert.Equal(t, token.User{Picture: "http://example.com/pic1.png"}, u)
 
-	u, err = setAvatar(mockAva{true, "http://example.com/pic1px.png"}, token.User{Picture: "http://example.com/pic1.png"})
+	u, err = setAvatar(mockAva{true, "http://example.com/pic1px.png"}, token.User{Picture: "http://example.com/pic1.png"}, client)
 	assert.NoError(t, err)
 	assert.Equal(t, token.User{Picture: "http://example.com/pic1px.png"}, u)
 
-	_, err = setAvatar(mockAva{false, ""}, token.User{Picture: "http://example.com/pic1.png"})
+	_, err = setAvatar(mockAva{false, ""}, token.User{Picture: "http://example.com/pic1.png"}, client)
 	assert.Error(t, err, "some error")
 }
 
@@ -75,7 +77,7 @@ type mockAva struct {
 	res string
 }
 
-func (m mockAva) Put(u token.User) (avatarURL string, err error) {
+func (m mockAva) Put(u token.User, client *http.Client) (avatarURL string, err error) {
 	if !m.ok {
 		return "", errors.New("some error")
 	}

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -98,7 +98,7 @@ func (e VerifyHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if u, err = setAvatar(e.AvatarSaver, u); err != nil {
+	if u, err = setAvatar(e.AvatarSaver, u, &http.Client{Timeout: 5 * time.Second}); err != nil {
 		rest.SendErrorJSON(w, r, e.L, http.StatusInternalServerError, err, "failed to save avatar to proxy")
 		return
 	}

--- a/provider/verify_test.go
+++ b/provider/verify_test.go
@@ -285,6 +285,6 @@ type mockAvatarSaverVerif struct {
 	url string
 }
 
-func (a mockAvatarSaverVerif) Put(u token.User) (avatarURL string, err error) {
+func (a mockAvatarSaverVerif) Put(u token.User, client *http.Client) (avatarURL string, err error) {
 	return a.url, a.err
 }


### PR DESCRIPTION
Implements azure aouth2. Handles basic user info as well as a separate authorized call required by azure to retrieve avatar. 

Note: the call hits beta API because production one is not supported yet, see https://github.com/microsoftgraph/microsoft-graph-docs/issues/3990

#55 