### PR TITLE
RBAC with multiple roles and chains-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ func main() {
 - `middleware.Auth` - requires authenticated user
 - `middleware.Admin` - requires authenticated admin user
 - `middleware.Trace` - doesn't require authenticated user, but adds user info to request
-- `middleware.RBAC` - requires authenticated user with passed role
+- `middleware.RBAC` - requires authenticated user with passed role(s)
 
 Also, there is a special middleware `middleware.UpdateUser` for population and modifying UserInfo in every request. See "Customization" for more details.
 

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -191,7 +191,7 @@ func (a *Authenticator) basicAdminUser(r *http.Request) bool {
 
 // RBAC middleware allows role based control for routes
 // this handler internally wrapped with auth(true) to avoid situation if RBAC defined without prior Auth
-func (a *Authenticator) RBAC(role string) func(http.Handler) http.Handler {
+func (a *Authenticator) RBAC(roles ...string) func(http.Handler) http.Handler {
 
 	f := func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
@@ -201,7 +201,14 @@ func (a *Authenticator) RBAC(role string) func(http.Handler) http.Handler {
 				return
 			}
 
-			if !strings.EqualFold(role, user.Role) {
+			var matched bool
+			for _, role := range roles {
+				if strings.EqualFold(role, user.Role) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
 				http.Error(w, "Access denied", http.StatusForbidden)
 				return
 			}

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -191,19 +191,23 @@ func (a *Authenticator) basicAdminUser(r *http.Request) bool {
 
 // RBAC middleware allows role based control for routes
 // this handler internally wrapped with auth(true) to avoid situation if RBAC defined without prior Auth
-func (a *Authenticator) RBAC(role string, next http.Handler) http.Handler {
-	fn := func(w http.ResponseWriter, r *http.Request) {
-		user, err := token.GetUserInfo(r)
-		if err != nil {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
+func (a *Authenticator) RBAC(role string) func(http.Handler) http.Handler {
 
-		if !strings.EqualFold(role, user.Role) {
-			http.Error(w, "Access denied", http.StatusForbidden)
-			return
+	f := func(h http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			user, err := token.GetUserInfo(r)
+			if err != nil {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			if !strings.EqualFold(role, user.Role) {
+				http.Error(w, "Access denied", http.StatusForbidden)
+				return
+			}
+			h.ServeHTTP(w, r)
 		}
-		next.ServeHTTP(w, r)
+		return a.auth(true)(http.HandlerFunc(fn)) // enforce auth
 	}
-	return a.auth(true)(http.HandlerFunc(fn)) // enforce auth
+	return f
 }

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -383,7 +383,7 @@ func TestRBAC(t *testing.T) {
 		w.WriteHeader(201)
 	})
 
-	mux.Handle("/authForEmployees", a.RBAC("employee")(handler))
+	mux.Handle("/authForEmployees", a.RBAC("someone", "employee")(handler))
 	mux.Handle("/authForExternals", a.RBAC("external")(handler))
 	server := httptest.NewServer(mux)
 	defer server.Close()

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -380,8 +380,8 @@ func TestRBAC(t *testing.T) {
 			Role:       "employee"}, u)
 		w.WriteHeader(201)
 	}
-	mux.Handle("/authForEmployees", a.RBAC("employee", http.HandlerFunc(handler)))
-	mux.Handle("/authForExternals", a.RBAC("external", http.HandlerFunc(handler)))
+	mux.Handle("/authForEmployees", a.RBAC("employee")(http.HandlerFunc(handler)))
+	mux.Handle("/authForExternals", a.RBAC("external")(http.HandlerFunc(handler)))
 	server := httptest.NewServer(mux)
 	defer server.Close()
 

--- a/middleware/user_updater.go
+++ b/middleware/user_updater.go
@@ -21,7 +21,7 @@ func (f UserUpdFunc) Update(user token.User) token.User {
 }
 
 // UpdateUser update user info with UserUpdater if it exists in request's context. Otherwise do nothing.
-// should be places after either Auth, Trace or AdminOnly middleware.
+// should be placed after either Auth, Trace. AdminOnly or RBAC middleware.
 func (a *Authenticator) UpdateUser(upd UserUpdater) func(http.Handler) http.Handler {
 	f := func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Converted RBAC middleware to a more traditional signature and added support of matching against multiple roles.

The reason for this change - in any modern framework supporting middleware chains (i.e. route.With(middleware, middleware2, ....) the old signature expecting handler as a part of the call is not smth usual and not easy to use. In addition, in practical use cases, one route (or group of routes) often allowed for multiple roles.

Another thing included in this PR - old test with ClaimUpdater counted on token's refresh and didn't work in normal circumstances. I'm not really sure how it even passed Actions CI, probably due to incorrect (different) clock on action workers. Replaced by pre-generated token and simplified test's code.

@kleash pls take a look. This change won't be backward compatible but I think it will be the right thing to do. 