### PR TITLE
verify avatar pattern from requests

### DIFF
--- a/avatar/noop_test.go
+++ b/avatar/noop_test.go
@@ -34,15 +34,25 @@ func TestNoOp_Get(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(proxy.Handler))
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/avatar")
-	require.NoError(t, err)
-	require.Equal(t, 200, resp.StatusCode)
-	require.Zero(t, resp.ContentLength)
-	body, err := ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Empty(t, body)
-	err = resp.Body.Close()
-	require.NoError(t, err)
+	{
+		resp, err := http.Get(ts.URL + "/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Zero(t, resp.ContentLength)
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Empty(t, body)
+		err = resp.Body.Close()
+		require.NoError(t, err)
+	}
+
+	{
+		resp, err := http.Get(ts.URL + "/avatar/invalid.image")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		err = resp.Body.Close()
+		require.NoError(t, err)
+	}
 
 }
 


### PR DESCRIPTION
this seems to be a little bit over paranoid, but the goal is to address "Uncontrolled data used in path expression" reported by codeql

Currently, we get the last element of the request's path as a file name and this unlikely may be used to access something unexpected. Either way, the change is adding strict verification of that element to make sure the request matches the allowed pattern for a valid image - `^[a-fA-F0-9]{40}\.image$`
