### PR TITLE
Add custom basic auth checker

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -66,11 +66,12 @@ type Opts struct {
 	AvatarRoutePath   string       // avatar routing prefix, i.e. "/api/v1/avatar", default `/avatar`
 	UseGravatar       bool         // for email based auth (verified provider) use gravatar service
 
-	AdminPasswd    string                  // if presented, allows basic auth with user admin and given password
-	AudienceReader token.Audience          // list of allowed aud values, default (empty) allows any
-	AudSecrets     bool                    // allow multiple secrets (secret per aud)
-	Logger         logger.L                // logger interface, default is no logging at all
-	RefreshCache   middleware.RefreshCache // optional cache to keep refreshed tokens
+	AdminPasswd      string                  // if presented, allows basic auth with user admin and given password
+	BasicAuthChecker token.BasicAuth         // user custom checker for basic auth, if one enabled "AdminPasswd" will ignore
+	AudienceReader   token.Audience          // list of allowed aud values, default (empty) allows any
+	AudSecrets       bool                    // allow multiple secrets (secret per aud)
+	Logger           logger.L                // logger interface, default is no logging at all
+	RefreshCache     middleware.RefreshCache // optional cache to keep refreshed tokens
 }
 
 // NewService initializes everything
@@ -80,9 +81,10 @@ func NewService(opts Opts) (res *Service) {
 		opts:   opts,
 		logger: opts.Logger,
 		authMiddleware: middleware.Authenticator{
-			Validator:    opts.Validator,
-			AdminPasswd:  opts.AdminPasswd,
-			RefreshCache: opts.RefreshCache,
+			Validator:        opts.Validator,
+			AdminPasswd:      opts.AdminPasswd,
+			BasicAuthChecker: opts.BasicAuthChecker,
+			RefreshCache:     opts.RefreshCache,
 		},
 		issuer:      opts.Issuer,
 		useGravatar: opts.UseGravatar,

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -76,8 +76,8 @@ func (a *Authenticator) auth(reqAuth bool) func(http.Handler) http.Handler {
 	f := func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 
-			// use admin user basic auth if enabled
-			if a.basicAdminUser(r) && a.BasicAuthChecker == nil {
+			// use admin user basic auth if enabled but ignore when BasicAuthChecker defined
+			if a.BasicAuthChecker == nil && a.basicAdminUser(r) {
 				r = token.SetUserInfo(r, adminUser)
 				h.ServeHTTP(w, r)
 				return

--- a/token/basic.go
+++ b/token/basic.go
@@ -1,0 +1,15 @@
+package token
+
+// BasicAuth defines interface to check credentials in store
+type BasicAuth interface {
+	Check(user, passwd string) (ok bool, userInfo User, err error)
+}
+
+// BasicAuthFunc type is an adapter to allow the use of ordinary functions as BasicAuth.
+type BasicAuthFunc func(user, passwd string) (ok bool, userInfo User, err error)
+
+// Check calls f(user,password). Second parameter need for pass user claims to request context
+// and check one in RBAC middleware if it's used
+func (f BasicAuthFunc) Check(user, passwd string) (bool, User, error) {
+	return f(user, passwd)
+}

--- a/token/basic_test.go
+++ b/token/basic_test.go
@@ -1,0 +1,28 @@
+package token
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBasic_BasicAuth(t *testing.T) {
+	ch := BasicAuthFunc(func(user, passwd string) (bool, User, error) {
+		if passwd == "test_p" {
+			return true, User{Name: user, Role: "test_r"}, nil
+		}
+		return false, User{}, errors.New("credentials check failed")
+	})
+
+	ok, ui, err := ch.Check("test_u", "test_p")
+	assert.True(t, ok)
+	assert.Nil(t, err)
+	assert.Equal(t, ui.Name, "test_u")
+	assert.Equal(t, ui.Role, "test_r")
+
+	ok, ui, err = ch.Check("test_u", "test_p_fake")
+	assert.True(t, !ok)
+	assert.NotNil(t, err)
+	assert.Equal(t, ui.Name, "")
+
+}


### PR DESCRIPTION
Would you consider proposal to add feature which implement user custom basic auth checker.

I tried wrote tests which covered all my changes, but can't add integration test because it required add additional input parameter for `prepService`. By default prepService defined `AdminPasswd` if I add hard `BasicAuthChecker` to `perpService` options it will brake `TestIntegrationBasicAuth` test. After test server started change service options unavailable (after call `prepService` return). If I can been have opportunity send service options to `prepService` as input parameter i can done integration test, but it require change func input signature for all call in test file. 