### PR TITLE
added sign in with apple

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,9 +465,11 @@ Then add an Apple provider that accepts the following parameters:
 ```
 
 **Limitation:**
-* Map a userName (if specific scope defined) can be only at first login for a user.
-Every next login with Apple, under account which sign in early, will no return field with userName and provider can't fetch the name until a user delete sign in for you service with Apple ID in  Apple account profile (security section).
-Provider always get user `UID` (`sub` claim) and `email` (if email scope defined) from claims of `IDToken`.
+* Map a userName (if specific scope defined) is only sent in the upon initial user sign up.
+Subsequent logins to your app using Sign In with Apple with the same account do not share any user info and will only return a user identifier in IDToken claims.
+This behaves correctly until a user delete sign in for you service with Apple ID in own Apple account profile (security section). 
+It is recommend that you securely cache the at first login containing the user info for bind it with a user UID at next login.
+Provider always get user `UID` (`sub` claim) in `IDToken`.
 
 * Apple doesn't have an API for fetch avatar and user info.
 

--- a/_example/main.go
+++ b/_example/main.go
@@ -80,6 +80,16 @@ func main() {
 	service.AddProvider("twitter", os.Getenv("AEXMPL_TWITTER_APIKEY"), os.Getenv("AEXMPL_TWITTER_APISEC"))
 	service.AddProvider("microsoft", os.Getenv("AEXMPL_MS_APIKEY"), os.Getenv("AEXMPL_MS_APISEC"))
 
+	// allow sign with apple id
+	appleCfg := provider.AppleConfig{
+		ClientID: os.Getenv("AEXMPL_APPLE_CID"),
+		TeamID:   os.Getenv("AEXMPL_APPLE_TID"),
+		KeyID:    os.Getenv("AEXMPL_APPLE_KEYID"), // private key identifier
+	}
+
+	if err := service.AddAppleProvider(appleCfg, provider.LoadApplePrivateKeyFromFile(os.Getenv("AEXMPL_APPLE_PRIVKEY_PATH"))); err != nil {
+		log.Fatalf("[ERROR] create AppleProvider failed: %v", err)
+	}
 	// allow anonymous user via custom (direct) provider
 	service.AddDirectProvider("anonymous", anonymousAuthProvider())
 

--- a/auth.go
+++ b/auth.go
@@ -257,6 +257,26 @@ func (s *Service) AddDevProvider(port int) {
 	s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))
 }
 
+// AddAppleProvider allow SignIn with Apple ID
+func (s *Service) AddAppleProvider(appleConfig provider.AppleConfig, privKeyLoader provider.PrivateKeyLoaderInterface) error {
+	p := provider.Params{
+		URL:         s.opts.URL,
+		JwtService:  s.jwtService,
+		Issuer:      s.issuer,
+		AvatarSaver: s.avatarProxy,
+		L:           s.logger,
+	}
+
+	// Error checking at create need for catch one when apple private key init
+	appleProvider, err := provider.NewApple(p, appleConfig, privKeyLoader)
+	if err != nil {
+		return errors.Wrap(err, "an AppleProvider creating failed")
+	}
+
+	s.providers = append(s.providers, provider.NewService(appleProvider))
+	return nil
+}
+
 // AddCustomProvider adds custom provider (e.g. https://gopkg.in/oauth2.v3)
 func (s *Service) AddCustomProvider(name string, client Client, copts provider.CustomHandlerOpt) {
 	p := provider.Params{

--- a/provider/apple.go
+++ b/provider/apple.go
@@ -1,0 +1,525 @@
+package provider
+
+// Implementation sign in with Apple for allow users to sign in to web services using their Apple ID.
+// For correct work this provider user must has Apple developer account and correct configure "sign in with Apple" at in
+// See more: https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api
+// and https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/incorporating_sign_in_with_apple_into_other_platforms
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/json"
+	"golang.org/x/oauth2"
+
+	"encoding/pem"
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/go-pkgz/auth/logger"
+	"github.com/go-pkgz/auth/token"
+	"github.com/go-pkgz/rest"
+	"github.com/pkg/errors"
+	"io/ioutil"
+
+	"net/http"
+	"net/url"
+	"os"
+
+	"strings"
+	"time"
+)
+
+const (
+	// appleAuthURL is the base authentication URL for sign in with Apple ID and fetch request code for user validation request.
+	appleAuthURL = "https://appleid.apple.com/auth/authorize"
+
+	// appleTokenURL is the endpoint for verifying tokens and get user unique ID and E-mail
+	appleTokenURL = "https://appleid.apple.com/auth/token" // #nosec
+
+	// appleRequestContentType is the valid type which apple REST API accept only
+	appleRequestContentType = "application/x-www-form-urlencoded"
+
+	// UserAgent required to every request to Apple REST API
+	defaultUserAgent = "github.com/go-pkgz/auth"
+
+	// AcceptJSONHeader is the content to accept from response
+	AcceptJSONHeader = "application/json"
+)
+
+// appleVerificationResponse is based on https://developer.apple.com/documentation/signinwithapplerestapi/tokenresponse
+type appleVerificationResponse struct {
+	// A token used to access allowed user data, but now not implemented public interface for it.
+	AccessToken string `json:"access_token"`
+
+	// Access token type, always equal the "bearer".
+	TokenType string `json:"token_type"`
+
+	// Access token expires time in seconds. Always equal 3600 seconds (1 hour)
+	ExpiresIn int `json:"expires_in"`
+
+	// The refresh token used to regenerate new access tokens.
+	RefreshToken string `json:"refresh_token"`
+
+	// Main JSON Web Token that contains the user’s identity information.
+	IDToken string `json:"id_token"`
+
+	// Used to capture any error returned in response. Always check error for empty
+	Error string `json:"error"`
+}
+
+// AppleConfig is the main oauth2 required parameters for "Sign in with Apple"
+type AppleConfig struct {
+	ClientID string // the identifier Services ID for your app created in Apple developer account.
+	TeamID   string // developer Team ID (10 characters), required for create JWT. It available, after signed in at developer account, by link: https://developer.apple.com/account/#/membership
+	KeyID    string // private key ID  assigned to private key obtain in Apple developer account
+
+	scopes       []string         // for this package allow only username scope and UID in token claims. Apple service API provide only "email" and "name" scope values (https://developer.apple.com/documentation/sign_in_with_apple/clientconfigi/3230955-scope)
+	privateKey   interface{}      // private key from Apple obtained in developer account (the keys section). Required for create the Client Secret (https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3262048)
+	publicKey    crypto.PublicKey // need for validate sign of token
+	clientSecret string           // is the JWT client secret will create after first call and then used until expired
+	jwkURL       string           // URL for fetch JWK Apple keys, need redefine for tests
+}
+
+// AppleHandler implements login via Apple ID
+type AppleHandler struct {
+	Params
+
+	// all of these fields specific to particular oauth2 provider
+	name string
+	// infoURL  string not implemented at Apple side
+	endpoint oauth2.Endpoint
+
+	mapUser func(jwt.MapClaims) token.User // map info from InfoURL to User
+	conf    AppleConfig                    // main config for Apple auth provider
+
+	PrivateKeyLoader PrivateKeyLoaderInterface // custom function interface for load private key
+
+}
+
+// PrivateKeyLoaderInterface interface for implement custom loader for Apple private key from user source
+type PrivateKeyLoaderInterface interface {
+	LoadPrivateKey() ([]byte, error)
+}
+
+// LoadFromFileFunc is the type for use pre-defined private key loader function
+// Path field must be set with actual path to private key file
+type LoadFromFileFunc struct {
+	Path string
+}
+
+// LoadApplePrivateKeyFromFile return instance for pre-defined loader function from local file
+func LoadApplePrivateKeyFromFile(path string) LoadFromFileFunc {
+	return LoadFromFileFunc{
+		Path: path,
+	}
+}
+
+// LoadPrivateKey implement pre-defined (built-in) PrivateKeyLoaderInterface interface method for load private key from local file
+func (lf LoadFromFileFunc) LoadPrivateKey() ([]byte, error) {
+	if lf.Path == "" {
+		return nil, errors.New("empty private key path not allowed")
+	}
+
+	kFile, err := os.Open(lf.Path)
+	if err != nil {
+		return nil, err
+	}
+	keyValue, err := ioutil.ReadAll(kFile)
+	if err != nil {
+		return nil, err
+	}
+	err = kFile.Close()
+	return keyValue, err
+}
+
+// NewApple create new AppleProvider instance with a user parameters
+// Private key must be set, when instance create call, for create `client_secret`
+func NewApple(p Params, appleCfg AppleConfig, privateKeyLoader PrivateKeyLoaderInterface) (*AppleHandler, error) {
+
+	if p.L == nil {
+		p.L = logger.NoOp
+	}
+	var emptyParams []string
+
+	// check required parameters filled
+	if appleCfg.ClientID == "" {
+		emptyParams = append(emptyParams, "ClientID")
+	}
+	if appleCfg.TeamID == "" {
+		emptyParams = append(emptyParams, "TeamID")
+	}
+	if appleCfg.KeyID == "" {
+		emptyParams = append(emptyParams, "KeyID")
+	}
+	if len(emptyParams) > 0 {
+		return nil, fmt.Errorf("required params missed: %s", strings.Join(emptyParams, ", "))
+	}
+
+	ah := AppleHandler{
+		Params: p,
+		name:   "apple", // static name for an Apple provider
+
+		conf: AppleConfig{
+			ClientID: appleCfg.ClientID,
+			TeamID:   appleCfg.TeamID,
+			KeyID:    appleCfg.KeyID,
+			scopes:   []string{"name"},
+			jwkURL:   appleKeysURL,
+		},
+
+		endpoint: oauth2.Endpoint{
+			AuthURL:  appleAuthURL,
+			TokenURL: appleTokenURL,
+		},
+
+		mapUser: func(claims jwt.MapClaims) token.User {
+			var usr token.User
+			if uid, ok := claims["sub"]; ok {
+				usr.ID = fmt.Sprintf("apple_%s", uid.(string))
+			}
+			return usr
+		},
+	}
+
+	if privateKeyLoader == nil {
+		return nil, errors.New("private key loader undefined")
+	}
+
+	ah.PrivateKeyLoader = privateKeyLoader
+
+	err := ah.initPrivateKey()
+	return &ah, err
+}
+
+// initPrivateKey parse Apple private key and assign to AppleHandler
+func (ah *AppleHandler) initPrivateKey() error {
+
+	sKey, err := ah.PrivateKeyLoader.LoadPrivateKey()
+	if err != nil {
+		return errors.Wrap(err, "problem with private key loading")
+	}
+
+	block, _ := pem.Decode(sKey)
+	if block == nil {
+		return errors.New("empty block after decoding")
+	}
+	ah.conf.privateKey, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return err
+	}
+	ah.conf.publicKey = ah.conf.privateKey.(*ecdsa.PrivateKey).Public()
+	ah.conf.clientSecret, err = ah.createClientSecret()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// tokenKeyFunc use for verify JWT sign, it receive the parsed token and should return the key for validating.
+func (ah *AppleHandler) tokenKeyFunc(jwtToken *jwt.Token) (interface{}, error) {
+	if jwtToken == nil {
+		return nil, errors.New("failed to call token keyFunc, because token is nil")
+	}
+	return ah.conf.publicKey, nil // extract public key from private key
+}
+
+// Name of the provider
+func (ah *AppleHandler) Name() string { return ah.name }
+
+// LoginHandler - GET */{provider-name}/login
+func (ah *AppleHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
+
+	ah.Logf("[DEBUG] login with %s", ah.Name())
+	// make state (random) and store in session
+	state, err := randToken()
+	if err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "failed to make oauth2 state")
+		return
+	}
+
+	cid, err := randToken()
+	if err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "failed to make claim's id")
+		return
+	}
+
+	claims := token.Claims{
+		Handshake: &token.Handshake{
+			State: state,
+			From:  r.URL.Query().Get("from"),
+		},
+		SessionOnly: r.URL.Query().Get("session") != "" && r.URL.Query().Get("session") != "0",
+		StandardClaims: jwt.StandardClaims{
+			Id:        cid,
+			Audience:  r.URL.Query().Get("site"),
+			ExpiresAt: time.Now().Add(30 * time.Minute).Unix(),
+			NotBefore: time.Now().Add(-1 * time.Minute).Unix(),
+		},
+	}
+
+	if _, err = ah.JwtService.Set(w, claims); err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "failed to set token")
+		return
+	}
+
+	// return login url
+	loginURL, err := ah.prepareLoginURL(state, r.URL.Path)
+	if err != nil {
+		errMsg := fmt.Sprintf("prepare login url for [%s] provider failed", ah.name)
+		ah.Logf("[ERROR] %s", errMsg)
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, errMsg)
+		return
+	}
+	ah.Logf("[DEBUG] login url %s, claims=%+v", loginURL, claims)
+
+	http.Redirect(w, r, loginURL, http.StatusFound)
+}
+
+// AuthHandler fills user info and redirects to "from" url. This is callback url redirected locally by browser
+// GET /callback
+func (ah AppleHandler) AuthHandler(w http.ResponseWriter, r *http.Request) {
+
+	// read response form data
+	if err := r.ParseForm(); err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "read callback response from data failed")
+		return
+	}
+
+	state := r.FormValue("state") // state value which sent with auth request
+	code := r.FormValue("code")   //  client code for validation
+
+	// response with user name filed return only one time at first login, next login  field user doesn't exist
+	// until user delete sign with Apple ID in account profile (security section)
+	// example response: {"name":{"firstName":"Chan","lastName":"Lu"},"email":"user@email.com"}
+	jUser := r.FormValue("user") // json string with user name
+
+	oauthClaims, _, err := ah.JwtService.Get(r)
+	if err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "failed to get token")
+		return
+	}
+
+	if oauthClaims.Handshake == nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusForbidden, nil, "invalid handshake token")
+		return
+	}
+
+	retrievedState := oauthClaims.Handshake.State
+	if retrievedState == "" || retrievedState != state {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusForbidden, nil, "unexpected state")
+		return
+	}
+
+	var resp appleVerificationResponse
+	err = ah.exchange(context.Background(), code, ah.makeRedirURL(r.URL.Path), &resp)
+	if err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "exchange failed")
+		return
+	}
+	ah.Logf("[DEBUG]response data %+v", resp)
+	if resp.Error != "" {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, nil, fmt.Sprintf("fetch IDtoken response error: %s", resp.Error))
+		return
+	}
+
+	// trying to fetch Apple public key (JWK) for verify token signature, it need for verify IDToken received from Apple
+	keySet, err := fetchAppleJWK(r.Context(), ah.conf.jwkURL)
+	if err != nil {
+		ah.L.Logf("failed to fetch JWK from Apple key service: " + err.Error())
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, nil, fmt.Sprintf("failed to fetch JWK from Apple key service: %s", resp.Error))
+		return
+	}
+
+	// get token claims for extract uid (and email or name if they exist in scope)
+	tokenClaims := jwt.MapClaims{}
+	_, err = jwt.ParseWithClaims(resp.IDToken, tokenClaims, keySet.keyFunc)
+	if err != nil {
+		ah.L.Logf("failed to get claims: " + err.Error())
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, nil, fmt.Sprintf("failed to token validation, key is invalid: %s", resp.Error))
+		return
+	}
+
+	u := ah.mapUser(tokenClaims)
+
+	u, err = setAvatar(ah.AvatarSaver, u, &http.Client{Timeout: 5 * time.Second})
+	if err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "failed to save avatar to proxy")
+		return
+	}
+
+	// try parse user name data if it exist in scope and service response
+	if jUser != "" {
+		ah.parseUserData(&u, jUser)
+	}
+
+	cid, err := randToken()
+	if err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "failed to make claim's id")
+		return
+	}
+
+	claims := token.Claims{
+		User: &u,
+		StandardClaims: jwt.StandardClaims{
+			Issuer:   ah.Issuer,
+			Id:       cid,
+			Audience: oauthClaims.Audience,
+		},
+		SessionOnly: false,
+	}
+
+	if _, err = ah.JwtService.Set(w, claims); err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "failed to set token")
+		return
+	}
+
+	ah.Logf("[DEBUG] user info %+v", u)
+
+	// redirect to back url if presented in login query params
+	if oauthClaims.Handshake != nil && oauthClaims.Handshake.From != "" {
+		http.Redirect(w, r, oauthClaims.Handshake.From, http.StatusTemporaryRedirect)
+		return
+	}
+	rest.RenderJSON(w, &u)
+
+}
+
+// LogoutHandler - GET /logout
+func (ah AppleHandler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
+	if _, _, err := ah.JwtService.Get(r); err != nil {
+		rest.SendErrorJSON(w, r, ah.L, http.StatusForbidden, err, "logout not allowed")
+		return
+	}
+	ah.JwtService.Reset(w)
+}
+
+// exchange sends the validation token request and gets access token and user claims
+// (e.g. https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens)
+func (ah *AppleHandler) exchange(ctx context.Context, code, redirectURI string, result *appleVerificationResponse) error {
+
+	// check client_secret for valid and recreate new (client_secret JWT) if required
+	if tkn, err := jwt.Parse(ah.conf.clientSecret, ah.tokenKeyFunc); err != nil || tkn == nil {
+		ah.conf.clientSecret, err = ah.createClientSecret()
+		if err != nil {
+			return errors.Wrap(err, "client secret create failed")
+		}
+	}
+
+	data := url.Values{}
+	data.Set("client_id", ah.conf.ClientID)
+	data.Set("client_secret", ah.conf.clientSecret) // JWT signed with Apple private key
+	data.Set("code", code)
+	data.Set("redirect_uri", redirectURI) // redirect URL can't refer to localhost and must have trusted certificate and https protocol
+	data.Set("grant_type", "authorization_code")
+
+	client := http.Client{Timeout: time.Second * 5}
+	req, err := http.NewRequestWithContext(ctx, "POST", ah.endpoint.TokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("content-type", appleRequestContentType)
+	req.Header.Add("accept", AcceptJSONHeader)
+	req.Header.Add("user-agent", defaultUserAgent) // apple requires a user agent
+
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// Trying to decode (unmarshal json) data of response
+	err = json.NewDecoder(res.Body).Decode(result)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling data from apple service response failed")
+	}
+
+	// If above operation done successfully checking a response code and error descriptions, if one exist.
+	// Apple service will response either 200 (OK) or 400 (any error).
+	if res.StatusCode != http.StatusOK || result.Error != "" {
+		return fmt.Errorf("apple token service error: %s", result.Error)
+	}
+
+	defer func() {
+		if err = res.Body.Close(); err != nil {
+			ah.L.Logf("[ERROR] close request body failed when get access token: %v", err)
+		}
+	}()
+
+	return err
+}
+
+// createClientSecret use for create the JWT client secret required to make requests to the Apple validation server.
+// for more details go to link: https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3262048
+func (ah *AppleHandler) createClientSecret() (string, error) {
+
+	if ah.conf.privateKey == nil {
+		return "", errors.New("private key can't be empty")
+	}
+	// Create a claims
+	now := time.Now()
+	exp := now.Add(time.Minute * 30).Unix() // default value
+
+	claims := &jwt.StandardClaims{
+		Issuer:    ah.conf.TeamID,
+		IssuedAt:  now.Unix(),
+		ExpiresAt: exp,
+		Audience:  "https://appleid.apple.com",
+		Subject:   ah.conf.ClientID,
+	}
+
+	tkn := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	tkn.Header["alg"] = "ES256"
+	tkn.Header["kid"] = ah.conf.KeyID
+
+	return tkn.SignedString(ah.conf.privateKey)
+}
+
+func (ah *AppleHandler) parseUserData(user *token.User, jUser string) {
+
+	type UserData struct {
+		Name struct {
+			FirstName string `json:"firstName"`
+			LastName  string `json:"lastName"`
+		} `json:"name"`
+		Email string `json:"email"`
+	}
+
+	var userData UserData
+
+	// Catch error for log only. No need break flow if user name doesn't exist
+	if err := json.Unmarshal([]byte(jUser), &userData); err != nil {
+		ah.L.Logf("[ERROR] failed to parse user data %s: %v", user, err)
+		return
+	}
+	user.Name = fmt.Sprintf("%s %s", userData.Name.FirstName, userData.Name.LastName)
+}
+
+func (ah *AppleHandler) prepareLoginURL(state, path string) (string, error) {
+
+	scopesList := strings.Join(ah.conf.scopes, " ")
+
+	authURL, err := url.Parse(ah.endpoint.AuthURL)
+	if err != nil {
+		return "", err
+	}
+
+	query := authURL.Query()
+	query.Set("state", state)
+	query.Set("response_type", "code")
+	query.Set("response_mode", "form_post")
+	query.Set("client_id", ah.conf.ClientID)
+	query.Set("scope", scopesList)
+	query.Set("redirect_uri", ah.makeRedirURL(path))
+	authURL.RawQuery = query.Encode()
+
+	return authURL.String(), nil
+
+}
+
+func (ah AppleHandler) makeRedirURL(path string) string {
+	elems := strings.Split(path, "/")
+	newPath := strings.Join(elems[:len(elems)-1], "/")
+
+	return strings.TrimRight(ah.URL, "/") + strings.TrimSuffix(newPath, "/") + urlCallbackSuffix
+}

--- a/provider/apple_pubkeys.go
+++ b/provider/apple_pubkeys.go
@@ -1,0 +1,178 @@
+package provider
+
+// This is implementation need for fetch and parse Apple public key to verify the ID token signature.
+// Apple endpoint can return multiple keys, and the count of keys can vary over time.
+// From this set of keys, select the key with the matching key identifier (kid) to verify the signature of any JSON Web Token (JWT) issued by Apple.
+// For more details go to link https://developer.apple.com/documentation/sign_in_with_apple/fetch_apple_s_public_key_for_verifying_token_signature
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"time"
+)
+
+// appleKeysURL is the endpoint URL for fetch Apple’s public key
+const appleKeysURL = "https://appleid.apple.com/auth/keys"
+
+// applePublicKey is the Apple public key object
+// Apple public key is a data structure that represents a cryptographic key as JSON Web Key (JWK)
+// based on RFC-7517 https://datatracker.ietf.org/doc/html/rfc7517
+type applePublicKey struct {
+	ID        string `json:"id"`
+	KeyType   string `json:"kty"`
+	Usage     string `json:"use"`
+	Algorithm string `json:"alg"`
+
+	publicKey *rsa.PublicKey
+}
+
+// appleRawKey is raw json object
+type appleRawKey struct {
+	KTY string `json:"kty"`
+	KID string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// fetchAppleJWK to make web request to Apple service for get Apple public keys (JWK)
+func fetchAppleJWK(ctx context.Context, keyURL string) (set appleKeySet, err error) {
+	client := http.Client{Timeout: time.Second * 5}
+
+	if keyURL == "" {
+		keyURL = appleKeysURL
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", keyURL, nil)
+
+	if err != nil {
+		return set, errors.Wrap(err, "failed to prepare new request for fetch Apple public keys")
+	}
+
+	req.Header.Add("accept", AcceptJSONHeader)
+	req.Header.Add("user-agent", defaultUserAgent) // apple requires a user agent
+
+	res, err := client.Do(req)
+	if err != nil {
+		return set, errors.Wrap(err, "failed to fetch Apple public keys")
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return set, errors.Wrap(err, "failed read data after Apple public key fetched")
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	set, err = parseAppleJWK(data)
+	if err != nil {
+		return set, errors.Wrap(err, "get set of apple public key failed")
+	}
+
+	return set, nil
+}
+
+// parseAppleJWK try parse keys data for return set of Apple public keys, if no errors
+func parseAppleJWK(keyData []byte) (set appleKeySet, err error) {
+
+	var rawKeys struct {
+		Keys []appleRawKey `json:"keys"`
+	}
+
+	set = appleKeySet{} // init key sets
+	keys := make(map[string]*applePublicKey)
+
+	if err = json.Unmarshal(keyData, &rawKeys); err != nil {
+		return set, errors.Wrap(err, "parse json data with Apple keys failed")
+	}
+	for _, rawKey := range rawKeys.Keys {
+		key, err := parseApplePublicKey(rawKey)
+		if err != nil {
+			return set, err // no idea to continue iterate keys if at least one return error, need will check all public keys
+		}
+		keys[key.ID] = key
+	}
+
+	set.keys = keys
+	return set, nil
+}
+
+// parseApplePublicKey to  make parse JWK data for create an Apple public key
+func parseApplePublicKey(rawKey appleRawKey) (key *applePublicKey, err error) {
+
+	key = &applePublicKey{
+		KeyType:   rawKey.KTY,
+		ID:        rawKey.KID,
+		Usage:     rawKey.Use,
+		Algorithm: rawKey.Alg,
+	}
+
+	// parse and create public key
+	if err := key.createApplePublicKey(rawKey.N, rawKey.E); err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}
+
+// createApplePublicKey need to decodes a base64-encoded larger integer from Apple's key format.
+func (apk *applePublicKey) createApplePublicKey(n, e string) error {
+
+	bufferN, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(n) // decode modulus
+	if err != nil {
+		return errors.Wrap(err, "failed to decode Apple public key modulus (n)")
+	}
+
+	bufferE, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(e) // decode exponent
+	if err != nil {
+		return errors.Wrap(err, "failed to decode Apple public key exponent (e)")
+	}
+
+	// create rsa public key from JWK data
+	apk.publicKey = &rsa.PublicKey{
+		N: big.NewInt(0).SetBytes(bufferN),
+		E: int(big.NewInt(0).SetBytes(bufferE).Int64()),
+	}
+	return nil
+}
+
+// appleKeySet is a set of Apple public keys
+type appleKeySet struct {
+	keys map[string]*applePublicKey
+}
+
+// get return Apple public key with specific KeyID (kid)
+func (aks *appleKeySet) get(kid string) (keys *applePublicKey, err error) {
+	if aks.keys == nil || len(aks.keys) == 0 {
+		return nil, errors.New("failed to get key in appleKeySet, key set is nil or empty")
+	}
+
+	if val, ok := aks.keys[kid]; ok {
+		return val, nil
+	}
+	return nil, fmt.Errorf("key with ID %s not found", kid)
+}
+
+// keyFunc use for JWT verify with specific public key
+func (aks *appleKeySet) keyFunc(token *jwt.Token) (interface{}, error) {
+
+	keyID, ok := token.Header["kid"].(string)
+	if !ok {
+		return nil, errors.New("get JWT kid header not found")
+	}
+	key, err := aks.get(keyID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return key.publicKey, nil
+}

--- a/provider/apple_pubkeys_test.go
+++ b/provider/apple_pubkeys_test.go
@@ -1,0 +1,226 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApplePublicKey_Fetch(t *testing.T) {
+	teardown := prepareAppleKeysTestServer(t, 8982)
+
+	defer teardown()
+
+	// valid response checking
+	ctx := context.Background()
+	url := fmt.Sprintf("http://127.0.0.1:%d/keys", 8982)
+	set, err := fetchAppleJWK(ctx, url)
+	assert.NoError(t, err)
+	assert.NotEqual(t, appleKeySet{}, set)
+
+	// check service response error
+	url = fmt.Sprintf("http://127.0.0.1:%d/error", 8982)
+	_, err = fetchAppleJWK(ctx, url)
+	assert.Error(t, err)
+
+	url = fmt.Sprintf("http://127.0.0.1:%d/no-answer", 8982)
+	ctx, cancelFunc := context.WithTimeout(ctx, time.Second*2)
+	_, err = fetchAppleJWK(ctx, url)
+	defer cancelFunc()
+	assert.Error(t, err)
+
+}
+
+func TestParseAppleJWK(t *testing.T) {
+	testKeys := `{
+					"keys": [
+					{
+					  "kty": "RSA",
+					  "kid": "86D88Kf",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "iGaLqP6y-SJCCBq5Hv6pGDbG_SQ11MNjH7rWHcCFYz4hGwHC4lcSurTlV8u3avoVNM8jXevG1Iu1SY11qInqUvjJur--hghr1b56OPJu6H1iKulSxGjEIyDP6c5BdE1uwprYyr4IO9th8fOwCPygjLFrh44XEGbDIFeImwvBAGOhmMB2AD1n1KviyNsH0bEB7phQtiLk-ILjv1bORSRl8AK677-1T8isGfHKXGZ_ZGtStDe7Lu0Ihp8zoUt59kx2o9uWpROkzF56ypresiIl4WprClRCjz8x6cPZXU2qNWhu71TQvUFwvIvbkE1oYaJMb0jcOTmBRZA2QuYw-zHLwQ",
+					  "e": "AQAB"
+					},
+					{
+					  "kty": "RSA",
+					  "kid": "eXaunmL",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "4dGQ7bQK8LgILOdLsYzfZjkEAoQeVC_aqyc8GC6RX7dq_KvRAQAWPvkam8VQv4GK5T4ogklEKEvj5ISBamdDNq1n52TpxQwI2EqxSk7I9fKPKhRt4F8-2yETlYvye-2s6NeWJim0KBtOVrk0gWvEDgd6WOqJl_yt5WBISvILNyVg1qAAM8JeX6dRPosahRVDjA52G2X-Tip84wqwyRpUlq2ybzcLh3zyhCitBOebiRWDQfG26EH9lTlJhll-p_Dg8vAXxJLIJ4SNLcqgFeZe4OfHLgdzMvxXZJnPp_VgmkcpUdRotazKZumj6dBPcXI_XID4Z4Z3OM1KrZPJNdUhxw",
+					  "e": "AQAB"
+					},
+					{
+					  "kty": "RSA",
+					  "kid": "YuyXoY",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "1JiU4l3YCeT4o0gVmxGTEK1IXR-Ghdg5Bzka12tzmtdCxU00ChH66aV-4HRBjF1t95IsaeHeDFRgmF0lJbTDTqa6_VZo2hc0zTiUAsGLacN6slePvDcR1IMucQGtPP5tGhIbU-HKabsKOFdD4VQ5PCXifjpN9R-1qOR571BxCAl4u1kUUIePAAJcBcqGRFSI_I1j_jbN3gflK_8ZNmgnPrXA0kZXzj1I7ZHgekGbZoxmDrzYm2zmja1MsE5A_JX7itBYnlR41LOtvLRCNtw7K3EFlbfB6hkPL-Swk5XNGbWZdTROmaTNzJhV-lWT0gGm6V1qWAK2qOZoIDa_3Ud0Gw",
+					  "e": "AQAB"
+					}
+				  ]
+				}`
+	testKeySet, err := parseAppleJWK([]byte(testKeys))
+	assert.NoError(t, err)
+
+	key, err := testKeySet.get("YuyXoY")
+	assert.NoError(t, err)
+	assert.Equal(t, key.ID, "YuyXoY")
+
+	testKeySet = appleKeySet{} // reset previous value
+	testKeySet, err = parseAppleJWK([]byte(`{"keys":[]}`))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(testKeySet.keys))
+
+	testKeySet = appleKeySet{} // reset previous value
+	testKeySet, err = parseAppleJWK([]byte(`{"keys":[{
+					  "kty": "RSA",
+					  "kid": "86D88Kf",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "invalid-value",
+					  "e": "invalid-value"
+					}]}`))
+	assert.Error(t, err, errors.New("failed to decode Apple public key modulus (n)"))
+
+	testKeySet, err = parseAppleJWK([]byte(`{"keys":[{
+					  "kty": "RSA",
+					  "kid": "86D88Kf",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "1JiU4l3YCeT4o0gVmxGTEK1IXR-Ghdg5Bzka12tzmtdCxU00ChH66aV-4HRBjF1t95IsaeHeDFRgmF0lJbTDTqa6_VZo2hc0zTiUAsGLacN6slePvDcR1IMucQGtPP5tGhIbU-HKabsKOFdD4VQ5PCXifjpN9R-1qOR571BxCAl4u1kUUIePAAJcBcqGRFSI_I1j_jbN3gflK_8ZNmgnPrXA0kZXzj1I7ZHgekGbZoxmDrzYm2zmja1MsE5A_JX7itBYnlR41LOtvLRCNtw7K3EFlbfB6hkPL-Swk5XNGbWZdTROmaTNzJhV-lWT0gGm6V1qWAK2qOZoIDa_3Ud0Gw",
+					  "e": "invalid-value"
+					}]}`))
+
+	assert.Error(t, err, errors.New("failed to decode Apple public key modulus (e)"))
+	testKeySet, err = parseAppleJWK([]byte(`{invalid-json}`))
+	assert.Error(t, err)
+}
+
+func TestAppleKeySet_Get(t *testing.T) {
+	testKeySet := appleKeySet{}
+	_, err := testKeySet.get("some-kid")
+	assert.Error(t, err, "failed to get key in appleKeySet, key set is nil or empty")
+
+	testKeySet, err = parseAppleJWK([]byte(`{"keys":[{
+					  "kty": "RSA",
+					  "kid": "86D88Kf",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "iGaLqP6y-SJCCBq5Hv6pGDbG_SQ11MNjH7rWHcCFYz4hGwHC4lcSurTlV8u3avoVNM8jXevG1Iu1SY11qInqUvjJur--hghr1b56OPJu6H1iKulSxGjEIyDP6c5BdE1uwprYyr4IO9th8fOwCPygjLFrh44XEGbDIFeImwvBAGOhmMB2AD1n1KviyNsH0bEB7phQtiLk-ILjv1bORSRl8AK677-1T8isGfHKXGZ_ZGtStDe7Lu0Ihp8zoUt59kx2o9uWpROkzF56ypresiIl4WprClRCjz8x6cPZXU2qNWhu71TQvUFwvIvbkE1oYaJMb0jcOTmBRZA2QuYw-zHLwQ",
+					  "e": "AQAB"
+					}]}`))
+	require.Nil(t, err)
+
+	apk, err := testKeySet.get("86D88Kf")
+	assert.Nil(t, err)
+	assert.Equal(t, apk.ID, "86D88Kf")
+
+	_, err = testKeySet.get("not-found-kid")
+	assert.Error(t, err, "key with ID some-kid not found")
+
+}
+
+func TestAppleKeySet_KeyFunc(t *testing.T) {
+
+	tokenHdr := map[string]interface{}{"kid": "86D88Kf"}
+	validToken := jwt.Token{Header: tokenHdr}
+	testKeySet, err := parseAppleJWK([]byte(`{"keys":[{
+					  "kty": "RSA",
+					  "kid": "86D88Kf",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "iGaLqP6y-SJCCBq5Hv6pGDbG_SQ11MNjH7rWHcCFYz4hGwHC4lcSurTlV8u3avoVNM8jXevG1Iu1SY11qInqUvjJur--hghr1b56OPJu6H1iKulSxGjEIyDP6c5BdE1uwprYyr4IO9th8fOwCPygjLFrh44XEGbDIFeImwvBAGOhmMB2AD1n1KviyNsH0bEB7phQtiLk-ILjv1bORSRl8AK677-1T8isGfHKXGZ_ZGtStDe7Lu0Ihp8zoUt59kx2o9uWpROkzF56ypresiIl4WprClRCjz8x6cPZXU2qNWhu71TQvUFwvIvbkE1oYaJMb0jcOTmBRZA2QuYw-zHLwQ",
+					  "e": "AQAB"
+					}]}`))
+	require.Nil(t, err)
+	assert.IsType(t, appleKeySet{}, testKeySet)
+	_, err = testKeySet.keyFunc(&validToken)
+	assert.NoError(t, err)
+
+	testKeySet, err = parseAppleJWK([]byte(`{"keys":[{
+					  "kty": "RSA",
+					  "kid": "eXaunmL",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "4dGQ7bQK8LgILOdLsYzfZjkEAoQeVC_aqyc8GC6RX7dq_KvRAQAWPvkam8VQv4GK5T4ogklEKEvj5ISBamdDNq1n52TpxQwI2EqxSk7I9fKPKhRt4F8-2yETlYvye-2s6NeWJim0KBtOVrk0gWvEDgd6WOqJl_yt5WBISvILNyVg1qAAM8JeX6dRPosahRVDjA52G2X-Tip84wqwyRpUlq2ybzcLh3zyhCitBOebiRWDQfG26EH9lTlJhll-p_Dg8vAXxJLIJ4SNLcqgFeZe4OfHLgdzMvxXZJnPp_VgmkcpUdRotazKZumj6dBPcXI_XID4Z4Z3OM1KrZPJNdUhxw",
+					  "e": "AQAB"
+					}]}`))
+	require.NoError(t, err)
+	assert.NotNil(t, testKeySet)
+
+	_, err = testKeySet.keyFunc(&validToken)
+	assert.Error(t, err, "key with ID 86D88Kf not found")
+
+	_, err = testKeySet.keyFunc(&jwt.Token{})
+	assert.Error(t, err, "get JWT kid header not found")
+}
+
+func prepareAppleKeysTestServer(t *testing.T, authPort int) func() {
+	//nolint dupl
+	ts := &http.Server{
+		Addr: fmt.Sprintf(":%d", authPort),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log.Printf("[MOCK APPLE KEYS SERVER] request %s %s %+v", r.Method, r.URL, r.Header)
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/keys"):
+
+				testKeys := `{
+					"keys": [
+					{
+					  "kty": "RSA",
+					  "kid": "86D88Kf",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "iGaLqP6y-SJCCBq5Hv6pGDbG_SQ11MNjH7rWHcCFYz4hGwHC4lcSurTlV8u3avoVNM8jXevG1Iu1SY11qInqUvjJur--hghr1b56OPJu6H1iKulSxGjEIyDP6c5BdE1uwprYyr4IO9th8fOwCPygjLFrh44XEGbDIFeImwvBAGOhmMB2AD1n1KviyNsH0bEB7phQtiLk-ILjv1bORSRl8AK677-1T8isGfHKXGZ_ZGtStDe7Lu0Ihp8zoUt59kx2o9uWpROkzF56ypresiIl4WprClRCjz8x6cPZXU2qNWhu71TQvUFwvIvbkE1oYaJMb0jcOTmBRZA2QuYw-zHLwQ",
+					  "e": "AQAB"
+					},
+					{
+					  "kty": "RSA",
+					  "kid": "eXaunmL",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "4dGQ7bQK8LgILOdLsYzfZjkEAoQeVC_aqyc8GC6RX7dq_KvRAQAWPvkam8VQv4GK5T4ogklEKEvj5ISBamdDNq1n52TpxQwI2EqxSk7I9fKPKhRt4F8-2yETlYvye-2s6NeWJim0KBtOVrk0gWvEDgd6WOqJl_yt5WBISvILNyVg1qAAM8JeX6dRPosahRVDjA52G2X-Tip84wqwyRpUlq2ybzcLh3zyhCitBOebiRWDQfG26EH9lTlJhll-p_Dg8vAXxJLIJ4SNLcqgFeZe4OfHLgdzMvxXZJnPp_VgmkcpUdRotazKZumj6dBPcXI_XID4Z4Z3OM1KrZPJNdUhxw",
+					  "e": "AQAB"
+					},
+					{
+					  "kty": "RSA",
+					  "kid": "YuyXoY",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "1JiU4l3YCeT4o0gVmxGTEK1IXR-Ghdg5Bzka12tzmtdCxU00ChH66aV-4HRBjF1t95IsaeHeDFRgmF0lJbTDTqa6_VZo2hc0zTiUAsGLacN6slePvDcR1IMucQGtPP5tGhIbU-HKabsKOFdD4VQ5PCXifjpN9R-1qOR571BxCAl4u1kUUIePAAJcBcqGRFSI_I1j_jbN3gflK_8ZNmgnPrXA0kZXzj1I7ZHgekGbZoxmDrzYm2zmja1MsE5A_JX7itBYnlR41LOtvLRCNtw7K3EFlbfB6hkPL-Swk5XNGbWZdTROmaTNzJhV-lWT0gGm6V1qWAK2qOZoIDa_3Ud0Gw",
+					  "e": "AQAB"
+					}
+				  ]
+				}`
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				_, err := w.Write([]byte(testKeys))
+				assert.NoError(t, err)
+			case strings.HasPrefix(r.URL.Path, "/error"):
+				_, err := w.Write([]byte("test error"))
+				assert.NoError(t, err)
+			case strings.HasPrefix(r.URL.Path, "/no-answer"):
+				time.Sleep(time.Second * 3)
+				return
+			default:
+				t.Fatalf("unexpected oauth request %s %s", r.Method, r.URL)
+			}
+		}),
+	}
+
+	go func() { _ = ts.ListenAndServe() }()
+
+	time.Sleep(time.Millisecond * 100) // let them start
+
+	return func() {
+		assert.NoError(t, ts.Close())
+	}
+}

--- a/provider/apple_test.go
+++ b/provider/apple_test.go
@@ -1,0 +1,635 @@
+package provider
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/go-pkgz/auth/logger"
+	"github.com/go-pkgz/auth/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type customLoader struct{} // implement custom private key loader interface
+
+func TestAppleHandler_NewApple(t *testing.T) {
+
+	testIDToken := `eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJ0ZXN0LmF1dGguZXhhbXBsZS5jb20iLCJzdWIiOiIwMDExMjIuNzg5M2Y3NmViZWRjNDExOGE3OTE3ZGFiOWE4YTllYTkuMTEyMiIsImlzcyI6Imh0dHBzOi8vYXBwbGVpZC5hcHBsZS5jb20iLCJleHAiOiIxOTIwNjQ3MTgyIiwiaWF0IjoiMTYyMDYzNzE4MiIsImVtYWlsIjoidGVzdEBlbWFpbC5jb20ifQ.CQCPa7ov-IdZ5bEKfhhnxEXafMAM_t6mj5OAnaoyy0A` // #nosec
+	p := Params{
+		URL:     "http://localhost",
+		Issuer:  "test-issuer",
+		Cid:     "cid",
+		Csecret: "cs",
+	}
+
+	aCfg := AppleConfig{
+		ClientID: "auth.example.com",
+		TeamID:   "AA11BB22CC",
+		KeyID:    "BS2A79VCTT",
+	}
+	cl := customLoader{}
+
+	ah, err := NewApple(p, aCfg, cl)
+	assert.NoError(t, err)
+	assert.IsType(t, &AppleHandler{}, ah)
+	assert.Equal(t, ah.name, "apple")
+	assert.Equal(t, ah.conf.ClientID, aCfg.ClientID)
+	assert.NotEmpty(t, ah.conf.privateKey)
+	assert.NotEmpty(t, ah.conf.clientSecret)
+
+	testTokenClaims := jwt.MapClaims{}
+	_, err = jwt.ParseWithClaims(testIDToken, testTokenClaims, ah.tokenKeyFunc)
+	assert.Error(t, err) // no need check token is valid for test token
+
+	// testing mapUser
+	u := ah.mapUser(testTokenClaims)
+	t.Logf("%+v", u)
+	assert.Equal(t, u.ID, "apple_001122.7893f76ebedc4118a7917dab9a8a9ea9.1122")
+
+	_, err = NewApple(p, aCfg, nil)
+	require.Error(t, err)
+
+	// check empty params
+	aCfg.ClientID = ""
+	_, err = NewApple(p, aCfg, cl)
+	assert.NotNil(t, err, "required params missed: ClientID")
+	aCfg.TeamID = ""
+	_, err = NewApple(p, aCfg, cl)
+	assert.NotNil(t, err, "required params missed: ClientID, TeamID")
+	aCfg.KeyID = ""
+	_, err = NewApple(p, aCfg, cl)
+	assert.NotNil(t, err, "required params missed: ClientID, TeamID, KeyID")
+}
+
+// TestAppleHandler_LoadPrivateKey need for testing pre-defined loader from local file
+func TestAppleHandler_LoadPrivateKey(t *testing.T) {
+	testValidKey := `-----BEGIN PRIVATE KEY-----
+MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgTxaHXzyuM85Znw7y
+SJ9XeeC8gqcpE/VLhZHGsnPPiPagCgYIKoZIzj0DAQehRANCAATnwlOv7I6eC3Ec
+/+GeYXT+hbcmhEVveDqLmNcHiXCR9XxJZXtpMRlcRfY8eaJpUdig27dfsbvpnfX5
+Ivx5tHkv
+-----END PRIVATE KEY-----` // #nosec
+	testPrivKeyFileName := "privKeyTest.tmp"
+
+	dir, err := ioutil.TempDir(os.TempDir(), testPrivKeyFileName)
+	assert.NoError(t, err)
+	assert.NotNil(t, dir)
+	if err != nil {
+		require.NoError(t, err)
+		return
+	}
+
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+
+	tmpfn := filepath.Join(dir, testPrivKeyFileName)
+	if err = ioutil.WriteFile(tmpfn, []byte(testValidKey), 0600); err != nil {
+		require.NoError(t, err)
+		return
+	}
+	assert.NoError(t, err)
+	p := Params{
+		URL:     "http://localhost",
+		Issuer:  "test-issuer",
+		Cid:     "cid",
+		Csecret: "cs",
+	}
+
+	aCfg := AppleConfig{
+		ClientID: "auth.example.com",
+		TeamID:   "AA11BB22CC",
+		KeyID:    "BS2A79VCTT",
+	}
+
+	ah, err := NewApple(p, aCfg, LoadApplePrivateKeyFromFile(tmpfn))
+	assert.NoError(t, err)
+	assert.IsType(t, &AppleHandler{}, ah)
+	assert.Equal(t, ah.name, "apple")
+	assert.Equal(t, ah.conf.ClientID, aCfg.ClientID)
+	assert.NotEmpty(t, ah.conf.privateKey)
+	assert.NotEmpty(t, ah.conf.clientSecret)
+
+}
+
+func TestAppleHandlerCreateClientSecret(t *testing.T) {
+	ah := &AppleHandler{}
+	tkn, err := ah.createClientSecret()
+	assert.Error(t, err)
+	assert.Empty(t, tkn)
+
+	ah, err = prepareAppleHandlerTest()
+	assert.NoError(t, err)
+	assert.IsType(t, &AppleHandler{}, ah)
+
+	tkn, err = ah.createClientSecret()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, tkn)
+
+	testClaims := jwt.MapClaims{}
+
+	parsedToken, err := jwt.ParseWithClaims(tkn, testClaims, ah.tokenKeyFunc)
+	require.NoError(t, err)
+	require.NotNil(t, parsedToken)
+	assert.True(t, parsedToken.Valid)
+
+	assert.Equal(t, "auth.example.com", testClaims["sub"])
+}
+
+func TestAppleParseUserData(t *testing.T) {
+
+	ah := AppleHandler{Params: Params{L: logger.NoOp}}
+
+	userNameClaimTest := `{"name":{"firstName":"test","lastName":"user"}}`
+	testUser := &token.User{Email: "user@example.com"}
+
+	ah.parseUserData(testUser, userNameClaimTest)
+	assert.Equal(t, testUser, &token.User{Name: "test user", Email: "user@example.com"})
+
+	ah.parseUserData(testUser, "invalid user name data")
+	assert.Equal(t, testUser, &token.User{Name: "test user", Email: "user@example.com"})
+}
+
+func TestPrepareLoginURL(t *testing.T) {
+	ah, err := prepareAppleHandlerTest()
+	assert.NoError(t, err)
+	assert.IsType(t, &AppleHandler{}, ah)
+
+	lURL, err := ah.prepareLoginURL("1112233", "apple-test/login")
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(lURL, ah.endpoint.AuthURL))
+
+	checkURL, err := url.Parse(lURL)
+	assert.NoError(t, err)
+	q := checkURL.Query()
+	assert.Equal(t, q.Get("state"), "1112233")
+	assert.Equal(t, q.Get("response_type"), "code")
+	assert.Equal(t, q.Get("response_mode"), "form_post")
+	assert.Equal(t, q.Get("client_id"), ah.conf.ClientID)
+}
+
+func TestAppleHandlerMakeRedirURL(t *testing.T) {
+	cases := []struct{ rootURL, route, out string }{
+		{"localhost:8080/", "/my/auth/path/apple", "localhost:8080/my/auth/path/callback"},
+		{"localhost:8080", "/auth/apple", "localhost:8080/auth/callback"},
+		{"localhost:8080/", "/auth/apple", "localhost:8080/auth/callback"},
+		{"localhost:8080", "/", "localhost:8080/callback"},
+		{"localhost:8080/", "/", "localhost:8080/callback"},
+		{"mysite.com", "", "mysite.com/callback"},
+	}
+
+	ah, err := prepareAppleHandlerTest()
+	assert.NoError(t, err)
+	assert.IsType(t, &AppleHandler{}, ah)
+
+	for i := range cases {
+		c := cases[i]
+		ah.URL = c.rootURL
+		assert.Equal(t, c.out, ah.makeRedirURL(c.route))
+	}
+}
+
+func TestAppleHandler_LoginHandler(t *testing.T) {
+
+	teardown := prepareAppleOauthTest(t, 8981, 8982, nil)
+	defer teardown()
+
+	jar, err := cookiejar.New(nil)
+	require.Nil(t, err)
+	client := &http.Client{Jar: jar, Timeout: 5 * time.Second}
+
+	resp, err := client.Get("http://localhost:8981/login?site=remark")
+	require.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
+	t.Logf("resp %s", string(body))
+	t.Logf("headers: %+v", resp.Header)
+
+	assert.Equal(t, 2, len(resp.Cookies()))
+	assert.Equal(t, "JWT", resp.Cookies()[0].Name)
+	assert.NotEqual(t, "", resp.Cookies()[0].Value, "token set")
+	assert.Equal(t, 2678400, resp.Cookies()[0].MaxAge)
+	assert.Equal(t, "XSRF-TOKEN", resp.Cookies()[1].Name)
+	assert.NotEqual(t, "", resp.Cookies()[1].Value, "xsrf cookie set")
+
+	u := token.User{}
+	err = json.Unmarshal(body, &u)
+	assert.Nil(t, err)
+	assert.Equal(t, token.User{ID: "mock_userid1", Email: "test@example.go"}, u)
+
+	tk := resp.Cookies()[0].Value
+	jwtSvc := token.NewService(token.Opts{SecretReader: token.SecretFunc(mockKeyStore), SecureCookies: false,
+		TokenDuration: time.Hour, CookieDuration: days31})
+
+	claims, err := jwtSvc.Parse(tk)
+	require.NoError(t, err)
+	t.Log(claims)
+	assert.Equal(t, "go-pkgz/auth", claims.Issuer)
+	assert.Equal(t, "remark", claims.Audience)
+
+}
+
+//nolint dupl
+func TestAppleHandler_LogoutHandler(t *testing.T) {
+
+	teardown := prepareAppleOauthTest(t, 8691, 8692, nil)
+	defer teardown()
+
+	jar, err := cookiejar.New(nil)
+	require.Nil(t, err)
+	client := &http.Client{Jar: jar, Timeout: 5 * time.Second}
+
+	req, err := http.NewRequest("GET", "http://localhost:8691/logout", nil)
+	require.Nil(t, err)
+	resp, err := client.Do(req)
+	require.Nil(t, err)
+	assert.Equal(t, 403, resp.StatusCode, "user not lagged in")
+
+	req, err = http.NewRequest("GET", "http://localhost:8691/logout", nil)
+	require.NoError(t, err)
+	expiration := int(365 * 24 * time.Hour.Seconds()) //nolint
+	req.AddCookie(&http.Cookie{Name: "JWT", Value: testJwtValid, HttpOnly: true, Path: "/", MaxAge: expiration, Secure: false})
+	req.Header.Add("X-XSRF-TOKEN", "random id")
+	resp, err = client.Do(req)
+	require.Nil(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	assert.Equal(t, 2, len(resp.Cookies()))
+	assert.Equal(t, "JWT", resp.Cookies()[0].Name, "token cookie cleared")
+	assert.Equal(t, "", resp.Cookies()[0].Value)
+	assert.Equal(t, "XSRF-TOKEN", resp.Cookies()[1].Name, "xsrf cookie cleared")
+	assert.Equal(t, "", resp.Cookies()[1].Value)
+
+}
+
+func TestAppleHandler_Exchange(t *testing.T) {
+	var testResponseToken string
+	teardown := prepareAppleOauthTest(t, 8981, 8982, &testResponseToken)
+	defer teardown()
+
+	ah, err := prepareAppleHandlerTest()
+	require.Nil(t, err)
+
+	ah.endpoint = oauth2.Endpoint{
+		AuthURL:  fmt.Sprintf("http://localhost:%d/login/oauth/authorize", 8981),
+		TokenURL: fmt.Sprintf("http://localhost:%d/login/oauth/access_token", 8982),
+	}
+
+	testAppleResponse := appleVerificationResponse{}
+	err = ah.exchange(context.Background(), "1122334455", "url/callback", &testAppleResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, &appleVerificationResponse{
+		AccessToken:  "MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3",
+		ExpiresIn:    3600,
+		TokenType:    "bearer",
+		RefreshToken: "IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk",
+		IDToken:      testResponseToken,
+	}, &testAppleResponse)
+
+	testAppleResponse = appleVerificationResponse{} // clear response for next checking
+	err = ah.exchange(context.Background(), "test-error", "url/callback", &testAppleResponse)
+	assert.Error(t, err)
+	assert.Equal(t, &appleVerificationResponse{
+		Error: "test error occurred",
+	}, &testAppleResponse)
+
+	err = ah.exchange(context.Background(), "test-json-error", "url/callback", &testAppleResponse)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "unmarshalling data from apple service response failed: invalid character 'i' looking for beginning of value")
+}
+
+func (cl customLoader) LoadPrivateKey() ([]byte, error) {
+
+	// valid p8 key
+	testValidKey := []byte(`-----BEGIN PRIVATE KEY-----
+MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgTxaHXzyuM85Znw7y
+SJ9XeeC8gqcpE/VLhZHGsnPPiPagCgYIKoZIzj0DAQehRANCAATnwlOv7I6eC3Ec
+/+GeYXT+hbcmhEVveDqLmNcHiXCR9XxJZXtpMRlcRfY8eaJpUdig27dfsbvpnfX5
+Ivx5tHkv
+-----END PRIVATE KEY-----`)
+
+	return testValidKey, nil
+}
+
+func prepareTestPrivateKey(t *testing.T) (filePath string, cancelFunc context.CancelFunc) {
+	testValidKey := `-----BEGIN PRIVATE KEY-----
+MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgTxaHXzyuM85Znw7y
+SJ9XeeC8gqcpE/VLhZHGsnPPiPagCgYIKoZIzj0DAQehRANCAATnwlOv7I6eC3Ec
+/+GeYXT+hbcmhEVveDqLmNcHiXCR9XxJZXtpMRlcRfY8eaJpUdig27dfsbvpnfX5
+Ivx5tHkv
+-----END PRIVATE KEY-----`
+	testPrivKeyFileName := "privKeyTest.tmp"
+
+	dir, err := ioutil.TempDir(os.TempDir(), testPrivKeyFileName)
+	assert.NoError(t, err)
+	assert.NotNil(t, dir)
+	if err != nil {
+		log.Fatal(err)
+		return "", nil
+	}
+
+	filePath = filepath.Join(dir, testPrivKeyFileName)
+	if err = ioutil.WriteFile(filePath, []byte(testValidKey), 0600); err != nil {
+		assert.NoError(t, err)
+		log.Fatal(err)
+		return "", nil
+	}
+	assert.NoError(t, err)
+	ctx, cancelCtx := context.WithTimeout(context.Background(), time.Second*60)
+
+	go func() {
+		<-ctx.Done()
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+	return filePath, cancelCtx
+}
+
+func prepareAppleHandlerTest() (*AppleHandler, error) {
+
+	p := Params{
+		URL:     "http://localhost",
+		Issuer:  "test-issuer",
+		Cid:     "cid",
+		Csecret: "cs",
+	}
+
+	aCfg := AppleConfig{
+		ClientID: "auth.example.com",
+		TeamID:   "AA11BB22CC",
+		KeyID:    "BS2A79VCTT",
+	}
+	cl := customLoader{}
+	return NewApple(p, aCfg, cl)
+}
+
+func prepareAppleOauthTest(t *testing.T, loginPort, authPort int, testToken *string) func() {
+	signKey, testJWK := createTestSignKeyPairs(t)
+	provider, err := prepareAppleHandlerTest()
+	assert.NoError(t, err)
+	assert.IsType(t, &AppleHandler{}, provider)
+
+	filePath, cancelCtx := prepareTestPrivateKey(t)
+	if cancelCtx == nil {
+		t.Fatal(errors.New("failed to create test private key file"))
+		return nil
+	}
+
+	provider.name = "mock"
+	provider.endpoint = oauth2.Endpoint{
+		AuthURL:  fmt.Sprintf("http://localhost:%d/login/oauth/authorize", authPort),
+		TokenURL: fmt.Sprintf("http://localhost:%d/login/oauth/access_token", authPort),
+	}
+	provider.conf.jwkURL = fmt.Sprintf("http://localhost:%d/keys", authPort)
+
+	provider.PrivateKeyLoader = LoadApplePrivateKeyFromFile(filePath)
+	require.NoError(t, err)
+
+	provider.mapUser = func(claims jwt.MapClaims) token.User {
+		var usr token.User
+		if uid, ok := claims["sub"]; ok {
+			usr.ID = fmt.Sprintf("mock_%s", uid.(string))
+		}
+		if email, ok := claims["email"]; ok {
+			usr.Email = email.(string)
+		}
+		return usr
+	}
+
+	// create self-signed JWT
+	testResponseToken, err := createTestResponseToken(signKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, testResponseToken)
+	if testToken != nil {
+		*testToken = testResponseToken
+	}
+
+	jwtService := token.NewService(token.Opts{
+		SecretReader: token.SecretFunc(mockKeyStore), SecureCookies: false, TokenDuration: time.Hour, CookieDuration: days31,
+		ClaimsUpd: token.ClaimsUpdFunc(func(claims token.Claims) token.Claims {
+			if claims.User != nil {
+				switch claims.User.ID {
+				case "mock_myuser2":
+					claims.User.SetBoolAttr("admin", true)
+				case "mock_myuser1":
+					claims.User.Picture = "http://example.com/custom.png"
+				}
+			}
+			return claims
+		}),
+	})
+
+	params := Params{URL: "url", Cid: "cid", Csecret: "csecret", JwtService: jwtService,
+		Issuer: "go-pkgz/auth", L: logger.Std}
+	provider.Params = params
+
+	svc := Service{Provider: provider}
+
+	ts := &http.Server{Addr: fmt.Sprintf(":%d", loginPort), Handler: http.HandlerFunc(svc.Handler)}
+
+	count := 0
+	useIds := []string{"myuser1", "myuser2"} // user for first ans second calls
+
+	//nolint dupl
+	oauth := &http.Server{
+		Addr: fmt.Sprintf(":%d", authPort),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log.Printf("[MOCK OAUTH] request %s %s %+v", r.Method, r.URL, r.Header)
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/login/oauth/authorize"):
+				state := r.URL.Query().Get("state")
+				w.Header().Add("Location", fmt.Sprintf("http://localhost:%d/callback?state=%s", loginPort, state))
+				w.WriteHeader(302)
+			case strings.HasPrefix(r.URL.Path, "/login/oauth/access_token"):
+				err := r.ParseForm()
+				assert.NoError(t, err)
+
+				res := fmt.Sprintf(`{
+					"access_token":"MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3",
+					"token_type":"bearer",
+					"expires_in":3600,
+					"refresh_token":"IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk",
+					"id_token":"%s"
+					}`, testResponseToken)
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+				switch r.Form.Get("code") {
+				case "test-error":
+
+					res = `{
+					"error":"test error occurred"
+					}`
+					w.WriteHeader(http.StatusBadRequest)
+					_, err := w.Write([]byte(res))
+					assert.NoError(t, err)
+					return
+
+				case "test-json-error":
+					res = `invalid json data`
+					w.WriteHeader(http.StatusBadRequest)
+					_, err := w.Write([]byte(res))
+					assert.NoError(t, err)
+					return
+				}
+
+				w.WriteHeader(200)
+				_, err = w.Write([]byte(res))
+				assert.NoError(t, err)
+			case strings.HasPrefix(r.URL.Path, "/user"):
+				res := fmt.Sprintf(`{
+					"id": "%s",
+					"name":"blah",
+					"picture":"http://exmple.com/pic1.png"
+					}`, useIds[count])
+				count++
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				w.WriteHeader(200)
+				_, err := w.Write([]byte(res))
+				assert.NoError(t, err)
+			case strings.HasPrefix(r.URL.Path, "/keys"):
+
+				testKeys := fmt.Sprintf(`{
+					"keys": [
+					%s,
+					{
+					  "kty": "RSA",
+					  "kid": "eXaunmL",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "4dGQ7bQK8LgILOdLsYzfZjkEAoQeVC_aqyc8GC6RX7dq_KvRAQAWPvkam8VQv4GK5T4ogklEKEvj5ISBamdDNq1n52TpxQwI2EqxSk7I9fKPKhRt4F8-2yETlYvye-2s6NeWJim0KBtOVrk0gWvEDgd6WOqJl_yt5WBISvILNyVg1qAAM8JeX6dRPosahRVDjA52G2X-Tip84wqwyRpUlq2ybzcLh3zyhCitBOebiRWDQfG26EH9lTlJhll-p_Dg8vAXxJLIJ4SNLcqgFeZe4OfHLgdzMvxXZJnPp_VgmkcpUdRotazKZumj6dBPcXI_XID4Z4Z3OM1KrZPJNdUhxw",
+					  "e": "AQAB"
+					},
+					{
+					  "kty": "RSA",
+					  "kid": "YuyXoY",
+					  "use": "sig",
+					  "alg": "RS256",
+					  "n": "1JiU4l3YCeT4o0gVmxGTEK1IXR-Ghdg5Bzka12tzmtdCxU00ChH66aV-4HRBjF1t95IsaeHeDFRgmF0lJbTDTqa6_VZo2hc0zTiUAsGLacN6slePvDcR1IMucQGtPP5tGhIbU-HKabsKOFdD4VQ5PCXifjpN9R-1qOR571BxCAl4u1kUUIePAAJcBcqGRFSI_I1j_jbN3gflK_8ZNmgnPrXA0kZXzj1I7ZHgekGbZoxmDrzYm2zmja1MsE5A_JX7itBYnlR41LOtvLRCNtw7K3EFlbfB6hkPL-Swk5XNGbWZdTROmaTNzJhV-lWT0gGm6V1qWAK2qOZoIDa_3Ud0Gw",
+					  "e": "AQAB"
+					}
+				  ]
+				}`, testJWK)
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				//provider.conf.publicKey = pub // re-define pubKey for JWK test
+				_, err := w.Write([]byte(testKeys))
+				assert.NoError(t, err)
+			default:
+				t.Fatalf("unexpected oauth request %s %s", r.Method, r.URL)
+			}
+		}),
+	}
+
+	go func() { _ = oauth.ListenAndServe() }()
+	go func() { _ = ts.ListenAndServe() }()
+
+	time.Sleep(time.Millisecond * 100) // let them start
+
+	return func() {
+
+		assert.NoError(t, ts.Close())
+		assert.NoError(t, oauth.Close())
+		cancelCtx() // delete test private key file
+	}
+}
+
+func createTestResponseToken(privKey interface{}) (string, error) {
+	claims := &jwt.MapClaims{
+		"iss":   "http://go.localhost.test",
+		"iat":   time.Now().Unix(),
+		"exp":   time.Now().Add(time.Second * 30).Unix(),
+		"aud":   "go-pkgz/auth",
+		"sub":   "userid1",
+		"email": "test@example.go",
+	}
+
+	tkn := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tkn.Header["alg"] = "RS256"
+	tkn.Header["kid"] = "112233"
+
+	return tkn.SignedString(privKey)
+}
+
+func createTestSignKeyPairs(t *testing.T) (privKey *rsa.PrivateKey, jwk string) {
+	privateStr := `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA4f5wg5l2hKsTeNem/V41fGnJm6gOdrj8ym3rFkEU/wT8RDtn
+SgFEZOQpHEgQ7JL38xUfU0Y3g6aYw9QT0hJ7mCpz9Er5qLaMXJwZxzHzAahlfA0i
+cqabvJOMvQtzD6uQv6wPEyZtDTWiQi9AXwBpHssPnpYGIn20ZZuNlX2BrClciHhC
+PUIIZOQn/MmqTD31jSyjoQoV7MhhMTATKJx2XrHhR+1DcKJzQBSTAGnpYVaqpsAR
+ap+nwRipr3nUTuxyGohBTSmjJ2usSeQXHI3bODIRe1AuTyHceAbewn8b462yEWKA
+Rdpd9AjQW5SIVPfdsz5B6GlYQ5LdYKtznTuy7wIDAQABAoIBAQCwia1k7+2oZ2d3
+n6agCAbqIE1QXfCmh41ZqJHbOY3oRQG3X1wpcGH4Gk+O+zDVTV2JszdcOt7E5dAy
+MaomETAhRxB7hlIOnEN7WKm+dGNrKRvV0wDU5ReFMRHg31/Lnu8c+5BvGjZX+ky9
+POIhFFYJqwCRlopGSUIxmVj5rSgtzk3iWOQXr+ah1bjEXvlxDOWkHN6YfpV5ThdE
+KdBIPGEVqa63r9n2h+qazKrtiRqJqGnOrHzOECYbRFYhexsNFz7YT02xdfSHn7gM
+IvabDDP/Qp0PjE1jdouiMaFHYnLBbgvlnZW9yuVf/rpXTUq/njxIXMmvmEyyvSDn
+FcFikB8pAoGBAPF77hK4m3/rdGT7X8a/gwvZ2R121aBcdPwEaUhvj/36dx596zvY
+mEOjrWfZhF083/nYWE2kVquj2wjs+otCLfifEEgXcVPTnEOPO9Zg3uNSL0nNQghj
+FuD3iGLTUBCtM66oTe0jLSslHe8gLGEQqyMzHOzYxNqibxcOZIe8Qt0NAoGBAO+U
+I5+XWjWEgDmvyC3TrOSf/KCGjtu0TSv30ipv27bDLMrpvPmD/5lpptTFwcxvVhCs
+2b+chCjlghFSWFbBULBrfci2FtliClOVMYrlNBdUSJhf3aYSG2Doe6Bgt1n2CpNn
+/iu37Y3NfemZBJA7hNl4dYe+f+uzM87cdQ214+jrAoGAXA0XxX8ll2+ToOLJsaNT
+OvNB9h9Uc5qK5X5w+7G7O998BN2PC/MWp8H+2fVqpXgNENpNXttkRm1hk1dych86
+EunfdPuqsX+as44oCyJGFHVBnWpm33eWQw9YqANRI+pCJzP08I5WK3osnPiwshd+
+hR54yjgfYhBFNI7B95PmEQkCgYBzFSz7h1+s34Ycr8SvxsOBWxymG5zaCsUbPsL0
+4aCgLScCHb9J+E86aVbbVFdglYa5Id7DPTL61ixhl7WZjujspeXZGSbmq0Kcnckb
+mDgqkLECiOJW2NHP/j0McAkDLL4tysF8TLDO8gvuvzNC+WQ6drO2ThrypLVZQ+ry
+eBIPmwKBgEZxhqa0gVvHQG/7Od69KWj4eJP28kq13RhKay8JOoN0vPmspXJo1HY3
+CKuHRG+AP579dncdUnOMvfXOtkdM4vk0+hWASBQzM9xzVcztCa+koAugjVaLS9A+
+9uQoqEeVNTckxx0S2bYevRy7hGQmUJTyQm3j1zEUR5jpdbL83Fbq
+-----END RSA PRIVATE KEY-----`
+	publicStr := `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4f5wg5l2hKsTeNem/V41
+fGnJm6gOdrj8ym3rFkEU/wT8RDtnSgFEZOQpHEgQ7JL38xUfU0Y3g6aYw9QT0hJ7
+mCpz9Er5qLaMXJwZxzHzAahlfA0icqabvJOMvQtzD6uQv6wPEyZtDTWiQi9AXwBp
+HssPnpYGIn20ZZuNlX2BrClciHhCPUIIZOQn/MmqTD31jSyjoQoV7MhhMTATKJx2
+XrHhR+1DcKJzQBSTAGnpYVaqpsARap+nwRipr3nUTuxyGohBTSmjJ2usSeQXHI3b
+ODIRe1AuTyHceAbewn8b462yEWKARdpd9AjQW5SIVPfdsz5B6GlYQ5LdYKtznTuy
+7wIDAQAB
+-----END PUBLIC KEY-----`
+
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(privateStr))
+	require.NoError(t, err)
+
+	publicKey, err := jwt.ParseRSAPublicKeyFromPEM([]byte(publicStr))
+	require.NoError(t, err)
+
+	// convert modulus
+	n := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(publicKey.N.Bytes())
+
+	// convert exponent
+	eBuff := make([]byte, 4)
+	binary.LittleEndian.PutUint32(eBuff, uint32(publicKey.E))
+	e := base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(eBuff)
+
+	JWK := struct {
+		Alg string `json:"alg"`
+		Kty string `json:"kty"`
+		Use string `json:"use"`
+		Kid string `json:"kid"`
+		E   string `json:"e"`
+		N   string `json:"n"`
+	}{Alg: "RS256", Kty: "RSA", Use: "sig", Kid: "112233", N: n, E: e[:4]}
+
+	var buffJwk []byte
+	buffJwk, err = json.Marshal(JWK)
+	require.NoError(t, err)
+	jwk = string(buffJwk)
+
+	return signKey, jwk
+}

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -110,6 +110,7 @@ func TestOauth2LoginSessionOnly(t *testing.T) {
 	t.Logf("%+v", res)
 }
 
+//nolint dupl
 func TestOauth2Logout(t *testing.T) {
 
 	teardown := prepOauth2Test(t, 8691, 8692)
@@ -228,6 +229,7 @@ func prepOauth2Test(t *testing.T, loginPort, authPort int) func() {
 	count := 0
 	useIds := []string{"myuser1", "myuser2"} // user for first ans second calls
 
+	//nolint dupl
 	oauth := &http.Server{
 		Addr: fmt.Sprintf(":%d", authPort),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Implementation of `Sign in with Apple`  #61

Apple API has some limit for implement full features compatible with the package:

1. Apple hasn't API for fetch avatar. If any one know how to do it let me know (also no `userInfo` api).

2. Fetch user name (if set in scope) possible only one, at first user login with a service. With next login  `userName` field doesn't exist in API response, until user will delete sign with an app in account profile (security section).

I will planning update the `Readme` after code review.

Waiting for your comments 
