### PR TITLE
add support of noava query param for oauth2

### DIFF
--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -77,7 +77,7 @@ func initOauth2Handler(p Params, service Oauth2Handler) Oauth2Handler {
 // Name returns provider name
 func (p Oauth2Handler) Name() string { return p.name }
 
-// LoginHandler - GET /login?from=redirect-back-url&site=siteID&session=1
+// LoginHandler - GET /login?from=redirect-back-url&[site|aud]=siteID&session=1&noava=1
 func (p Oauth2Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	p.Logf("[DEBUG] login with %s", p.Name())
@@ -94,6 +94,11 @@ func (p Oauth2Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	aud := r.URL.Query().Get("site") // legacy, for back compat
+	if aud == "" {
+		aud = r.URL.Query().Get("aud")
+	}
+
 	claims := token.Claims{
 		Handshake: &token.Handshake{
 			State: state,
@@ -102,10 +107,11 @@ func (p Oauth2Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		SessionOnly: r.URL.Query().Get("session") != "" && r.URL.Query().Get("session") != "0",
 		StandardClaims: jwt.StandardClaims{
 			Id:        cid,
-			Audience:  r.URL.Query().Get("site"),
+			Audience:  aud,
 			ExpiresAt: time.Now().Add(30 * time.Minute).Unix(),
 			NotBefore: time.Now().Add(-1 * time.Minute).Unix(),
 		},
+		NoAva: r.URL.Query().Get("noava") == "1",
 	}
 
 	if _, err := p.JwtService.Set(w, claims); err != nil {
@@ -180,6 +186,9 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 	p.Logf("[DEBUG] got raw user info %+v", jData)
 
 	u := p.mapUser(jData, data)
+	if oauthClaims.NoAva {
+		u.Picture = "" // reset picture on no avatar request
+	}
 	u, err = setAvatar(p.AvatarSaver, u, client)
 	if err != nil {
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "failed to save avatar to proxy")
@@ -199,6 +208,7 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 			Audience: oauthClaims.Audience,
 		},
 		SessionOnly: oauthClaims.SessionOnly,
+		NoAva:       oauthClaims.NoAva,
 	}
 
 	if _, err = p.JwtService.Set(w, claims); err != nil {

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -110,6 +110,41 @@ func TestOauth2LoginSessionOnly(t *testing.T) {
 	t.Logf("%+v", res)
 }
 
+func TestOauth2LoginNoAva(t *testing.T) {
+
+	teardown := prepOauth2Test(t, 8981, 8982)
+	defer teardown()
+
+	jar, err := cookiejar.New(nil)
+	require.Nil(t, err)
+	client := &http.Client{Jar: jar, Timeout: 5 * time.Second}
+
+	// check non-admin, session
+	resp, err := client.Get("http://localhost:8981/login?site=remark&noava=1")
+	require.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 2, len(resp.Cookies()))
+	assert.Equal(t, "JWT", resp.Cookies()[0].Name)
+	assert.NotEqual(t, "", resp.Cookies()[0].Value, "token set")
+	assert.NotEqual(t, 0, resp.Cookies()[0].MaxAge)
+	assert.Equal(t, "XSRF-TOKEN", resp.Cookies()[1].Name)
+	assert.NotEqual(t, "", resp.Cookies()[1].Value, "xsrf cookie set")
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.Nil(t, err)
+
+	req.AddCookie(resp.Cookies()[0])
+	req.AddCookie(resp.Cookies()[1])
+	req.Header.Add("X-XSRF-TOKEN", resp.Cookies()[1].Value)
+
+	jwtService := token.NewService(token.Opts{SecretReader: token.SecretFunc(mockKeyStore)})
+	res, _, err := jwtService.Get(req)
+	require.Nil(t, err)
+	assert.Equal(t, "http://example.com/fake.png", res.User.Picture)
+	assert.Equal(t, true, res.NoAva)
+	t.Logf("%+v", res)
+}
+
 func TestOauth2Logout(t *testing.T) {
 
 	teardown := prepOauth2Test(t, 8691, 8692)
@@ -210,7 +245,9 @@ func prepOauth2Test(t *testing.T, loginPort, authPort int) func() {
 				case "mock_myuser2":
 					claims.User.SetBoolAttr("admin", true)
 				case "mock_myuser1":
-					claims.User.Picture = "http://example.com/custom.png"
+					if !claims.NoAva {
+						claims.User.Picture = "http://example.com/custom.png"
+					}
 				}
 			}
 			return claims
@@ -284,5 +321,9 @@ func mockKeyStore(string) (string, error) { return "12345", nil }
 type mockAvatarSaver struct{}
 
 func (m *mockAvatarSaver) Put(u token.User, client *http.Client) (avatarURL string, err error) {
-	return "http://example.com/ava12345.png", nil
+	if u.Picture != "" {
+		return "http://example.com/ava12345.png", nil
+	}
+	return "http://example.com/fake.png", nil
+
 }

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -24,6 +24,7 @@ type Claims struct {
 	User        *User      `json:"user,omitempty"` // user info
 	SessionOnly bool       `json:"sess_only,omitempty"`
 	Handshake   *Handshake `json:"handshake,omitempty"` // used for oauth handshake
+	NoAva       bool       `json:"no-ava,omitempty"`    // disable avatar, always use identicon
 }
 
 // Handshake used for oauth handshake


### PR DESCRIPTION
with all the paranoid measures we still force involuntary exposure of user's avatar. On the service level, this can be disabled with the claim's updater, but there is no user-level solution.

This PR adds support of an optional "noava" param to the login query. In this case, the real avatar from the oauth2 provider will be dropped and an automatic (identicoin) avatar will be used instead. Flipping thins logic (i.e. dropping avatar by default) will be even better, but it may break back-compatibility.

