### PR TITLE
Add Audience, ExpiresAt and NotBefore to telegram JWT token

### DIFF
--- a/provider/apple.go
+++ b/provider/apple.go
@@ -217,7 +217,7 @@ func (ah *AppleHandler) initPrivateKey() error {
 	return nil
 }
 
-// tokenKeyFunc use for verify JWT sign, it receive the parsed token and should return the key for validating.
+// tokenKeyFunc use for verify JWT sign, it receives the parsed token and should return the key for validating.
 func (ah *AppleHandler) tokenKeyFunc(jwtToken *jwt.Token) (interface{}, error) {
 	if jwtToken == nil {
 		return nil, errors.New("failed to call token keyFunc, because token is nil")

--- a/provider/telegram.go
+++ b/provider/telegram.go
@@ -242,8 +242,11 @@ func (th *TelegramHandler) LoginHandler(w http.ResponseWriter, r *http.Request) 
 	claims := authtoken.Claims{
 		User: &u,
 		StandardClaims: jwt.StandardClaims{
-			Id:     queryToken,
-			Issuer: th.ProviderName,
+			Audience:  r.URL.Query().Get("site"),
+			Id:        queryToken,
+			Issuer:    th.ProviderName,
+			ExpiresAt: time.Now().Add(30 * time.Minute).Unix(),
+			NotBefore: time.Now().Add(-1 * time.Minute).Unix(),
 		},
 		SessionOnly: false, // TODO
 	}
@@ -261,11 +264,11 @@ func (th *TelegramHandler) LoginHandler(w http.ResponseWriter, r *http.Request) 
 	delete(th.requests.data, queryToken)
 }
 
-// AuthHandler does nothing since we're don't have any callbacks
-func (th *TelegramHandler) AuthHandler(w http.ResponseWriter, r *http.Request) {}
+// AuthHandler does nothing since we don't have any callbacks
+func (th *TelegramHandler) AuthHandler(_ http.ResponseWriter, _ *http.Request) {}
 
 // LogoutHandler - GET /logout
-func (th *TelegramHandler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
+func (th *TelegramHandler) LogoutHandler(w http.ResponseWriter, _ *http.Request) {
 	th.TokenService.Reset(w)
 }
 


### PR DESCRIPTION
Likely solves #92. Btw we don't have any tests for cookies in telegram auth.