### PR TITLE
Direct with custom user id func

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: install golangci-lint and goveralls
         run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.39.0
+          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.41.0
           GO111MODULE=off go get -u -v github.com/mattn/goveralls
 
       - name: run linters

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,14 +26,13 @@ linters-settings:
 linters:
   enable:
     - megacheck
-    - golint
+    - revive
     - govet
     - unconvert
     - megacheck
     - structcheck
     - gas
     - gocyclo
-    - dupl
     - misspell
     - unparam
     - varcheck

--- a/auth.go
+++ b/auth.go
@@ -309,6 +309,23 @@ func (s *Service) AddDirectProvider(name string, credChecker provider.CredChecke
 	s.authMiddleware.Providers = s.providers
 }
 
+// AddDirectProviderWithUserIDFunc adds provider with direct check against data store and sets custom UserIDFunc allows
+// to modify user's ID on the client side.
+// it doesn't do any handshake and uses provided credChecker to verify user and password from the request
+func (s *Service) AddDirectProviderWithUserIDFunc(name string, credChecker provider.CredChecker, ufn provider.UserIDFunc) {
+	dh := provider.DirectHandler{
+		L:            s.logger,
+		ProviderName: name,
+		Issuer:       s.issuer,
+		TokenService: s.jwtService,
+		CredChecker:  credChecker,
+		AvatarSaver:  s.avatarProxy,
+		UserIDFunc:   ufn,
+	}
+	s.providers = append(s.providers, provider.NewService(dh))
+	s.authMiddleware.Providers = s.providers
+}
+
 // AddVerifProvider adds provider user's verification sent by sender
 func (s *Service) AddVerifProvider(name, msgTmpl string, sender provider.Sender) {
 	dh := provider.VerifyHandler{

--- a/auth_test.go
+++ b/auth_test.go
@@ -236,7 +236,7 @@ func TestIntegrationList(t *testing.T) {
 
 	b, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, `["dev","github","custom123","direct","email"]`+"\n", string(b))
+	assert.Equal(t, `["dev","github","custom123","direct","direct_custom","email"]`+"\n", string(b))
 }
 
 func TestIntegrationUserInfo(t *testing.T) {
@@ -356,6 +356,47 @@ func TestDirectProvider(t *testing.T) {
 	assert.Nil(t, err)
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
+
+	assert.Contains(t, string(body), `"name":"dev_direct","id":"direct_38773b45e3a477434abb6d08668358a2b0ddd2f5"`)
+
+	require.Equal(t, 2, len(resp.Cookies()))
+	assert.Equal(t, "JWT", resp.Cookies()[0].Name)
+	assert.NotEqual(t, "", resp.Cookies()[0].Value, "token set")
+	assert.Equal(t, 86400, resp.Cookies()[0].MaxAge)
+	assert.Equal(t, "XSRF-TOKEN", resp.Cookies()[1].Name)
+	assert.NotEqual(t, "", resp.Cookies()[1].Value, "xsrf cookie set")
+
+	resp, err = client.Get("http://127.0.0.1:8089/private")
+	require.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.NoError(t, resp.Body.Close())
+}
+
+func TestDirectProvider_WithCustomUserIDFunc(t *testing.T) {
+	_, teardown := prepService(t)
+	defer teardown()
+
+	// login
+	jar, err := cookiejar.New(nil)
+	require.Nil(t, err)
+	client := &http.Client{Jar: jar, Timeout: 5 * time.Second}
+	resp, err := client.Get("http://127.0.0.1:8089/auth/direct_custom/login?user=dev_direct&passwd=bad")
+	require.Nil(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, 403, resp.StatusCode)
+
+	resp, err = client.Get("http://127.0.0.1:8089/auth/direct_custom/login?user=dev_direct&passwd=password")
+	require.Nil(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
+	t.Logf("resp %s", string(body))
+	t.Logf("headers: %+v", resp.Header)
+
+	assert.Contains(t, string(body), `"name":"dev_direct","id":"direct_custom_blah"`)
+
 	require.Equal(t, 2, len(resp.Cookies()))
 	assert.Equal(t, "JWT", resp.Cookies()[0].Name)
 	assert.NotEqual(t, "", resp.Cookies()[0].Value, "token set")
@@ -439,6 +480,16 @@ func prepService(t *testing.T) (svc *Service, teardown func()) { //nolint unpara
 	svc.AddDirectProvider("direct", provider.CredCheckerFunc(func(user, password string) (ok bool, err error) {
 		return user == "dev_direct" && password == "password", nil
 	}))
+
+	// add direct provider with custom user id func
+	svc.AddDirectProviderWithUserIDFunc("direct_custom",
+		provider.CredCheckerFunc(func(user, password string) (ok bool, err error) {
+			return user == "dev_direct" && password == "password", nil
+		}),
+		func(user string, r *http.Request) string {
+			return "blah"
+		},
+	)
 
 	svc.AddVerifProvider("email", "{{.Token}}", &sender)
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -395,7 +395,7 @@ func TestDirectProvider_WithCustomUserIDFunc(t *testing.T) {
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
 
-	assert.Contains(t, string(body), `"name":"dev_direct","id":"direct_custom_blah"`)
+	assert.Contains(t, string(body), `"name":"dev_direct","id":"direct_custom_5bf1fd927dfb8679496a2e6cf00cbe50c1c87145"`)
 
 	require.Equal(t, 2, len(resp.Cookies()))
 	assert.Equal(t, "JWT", resp.Cookies()[0].Name)

--- a/provider/apple.go
+++ b/provider/apple.go
@@ -122,15 +122,15 @@ func (lf LoadFromFileFunc) LoadPrivateKey() ([]byte, error) {
 		return nil, errors.New("empty private key path not allowed")
 	}
 
-	kFile, err := os.Open(lf.Path)
+	keyFile, err := os.Open(lf.Path)
 	if err != nil {
 		return nil, err
 	}
-	keyValue, err := ioutil.ReadAll(kFile)
+	keyValue, err := ioutil.ReadAll(keyFile)
 	if err != nil {
 		return nil, err
 	}
-	err = kFile.Close()
+	err = keyFile.Close()
 	return keyValue, err
 }
 

--- a/provider/direct.go
+++ b/provider/direct.go
@@ -98,7 +98,7 @@ func (p DirectHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	userID := p.ProviderName + "_" + token.HashID(sha1.New(), creds.User)
 	if p.UserIDFunc != nil {
-		userID = p.ProviderName + "_" + p.UserIDFunc(creds.User, r)
+		userID = p.ProviderName + "_" + token.HashID(sha1.New(), p.UserIDFunc(creds.User, r))
 	}
 
 	u := token.User{

--- a/provider/direct.go
+++ b/provider/direct.go
@@ -29,12 +29,16 @@ type DirectHandler struct {
 	TokenService TokenService
 	Issuer       string
 	AvatarSaver  AvatarSaver
+	UserIDFunc   UserIDFunc
 }
 
 // CredChecker defines interface to check credentials
 type CredChecker interface {
 	Check(user, password string) (ok bool, err error)
 }
+
+// UserIDFunc allows to provide custom func making userID instead of the default based on user's name hash
+type UserIDFunc func(user string, r *http.Request) string
 
 // CredCheckerFunc type is an adapter to allow the use of ordinary functions as CredsChecker.
 type CredCheckerFunc func(user, password string) (ok bool, err error)
@@ -91,9 +95,15 @@ func (p DirectHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		rest.SendErrorJSON(w, r, p.L, http.StatusForbidden, nil, "incorrect user or password")
 		return
 	}
+
+	userID := p.ProviderName + "_" + token.HashID(sha1.New(), creds.User)
+	if p.UserIDFunc != nil {
+		userID = p.ProviderName + "_" + p.UserIDFunc(creds.User, r)
+	}
+
 	u := token.User{
 		Name: creds.User,
-		ID:   p.ProviderName + "_" + token.HashID(sha1.New(), creds.User),
+		ID:   userID,
 	}
 	u, err = setAvatar(p.AvatarSaver, u, &http.Client{Timeout: 5 * time.Second})
 	if err != nil {

--- a/provider/direct_test.go
+++ b/provider/direct_test.go
@@ -121,7 +121,7 @@ func TestDirect_LoginHandlerCustomUserID(t *testing.T) {
 	require.NoError(t, err)
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, 200, rr.Code)
-	assert.Equal(t, `{"name":"myuser","id":"test_myuser_custom_id","picture":""}`+"\n", rr.Body.String())
+	assert.Equal(t, `{"name":"myuser","id":"test_18c4eec1ecbe23902609e999c4d3da997e7ac10f","picture":""}`+"\n", rr.Body.String())
 }
 
 func TestDirect_LoginHandlerFailed(t *testing.T) {


### PR DESCRIPTION
The direct provider uses just the name (hashed) to make a user ID. In many cases this is exactly what is needed, i.e. login with user/passwd may expect unique user names, however in some tricky cases we may want to change the default behavior. For example, the implementation of an anonymous provider, where no password is even passed and uniqueness on the name can not be expected.

The PR adds support of `UserIDFunc` overriding a part of the id. The prefix (provider name) still mandated but the rest can be whatever user like. It accepts both name and http.Request params, so it is possible to generate id based on the user name and mix in some ip parts.

I'm not sure if we should enforce hashing of `UserIDFunc` result or left it to the caller