### PR TITLE
Allow to configure DevServer to return email

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,22 @@ It will run fake aouth2 "server" on port :8084 and user could login with any use
 
 _Warning: this is not the real oauth2 server but just a small fake thing for development and testing only. Don't use `dev` provider with any production code._
 
+By default, Dev provider doesn't return `email` claim from `/user` endpoint, to match behaviour of other providers which only request minimal scopes.
+However sometimes it is useful to have `email` included into user info. This can be done by configuring `devAuthServer.GetEmailFn` function:
+
+```go
+    go func() {
+		devAuthServer, err := service.DevAuth()
+		devOauth2Srv.GetEmailFn = func(username string) string {
+			return username + "@example.com"
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+		devAuthServer.Run()
+	}()
+```
+
 ### Other ways to authenticate
 
 In addition to the primary method (i.e. JWT cookie with XSRF header) there are two more ways to authenticate:

--- a/provider/dev_provider_test.go
+++ b/provider/dev_provider_test.go
@@ -29,6 +29,9 @@ func TestDevProvider(t *testing.T) {
 	devProvider := NewDev(params)
 	s := Service{Provider: devProvider}
 	devOauth2Srv := DevAuthServer{Provider: devProvider, Automatic: true, username: "dev_user", L: logger.Std}
+	devOauth2Srv.GetEmailFn = func(username string) string {
+		return username + "@example.com"
+	}
 
 	router := http.NewServeMux()
 	router.Handle("/auth/dev/", http.HandlerFunc(s.Handler))
@@ -67,7 +70,7 @@ func TestDevProvider(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, token.User{Name: "dev_user", ID: "dev_user",
-		Picture: "http://127.0.0.1:18084/avatar?user=dev_user", IP: ""}, *claims.User)
+		Picture: "http://127.0.0.1:18084/avatar?user=dev_user", IP: "", Email: "dev_user@example.com"}, *claims.User)
 
 	// check avatar
 	resp, err = client.Get("http://127.0.0.1:18084/avatar?user=dev_user")


### PR DESCRIPTION
Could be useful in testing, when other providers request email scope.