### PR TITLE
support both personal and work/school Microsoft accounts

### DIFF
--- a/provider/providers.go
+++ b/provider/providers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1" //nolint
 	"encoding/json"
 	"fmt"
+
 	"github.com/dghubble/oauth1"
 	"github.com/dghubble/oauth1/twitter"
 	"github.com/go-pkgz/auth/token"
@@ -173,7 +174,7 @@ func NewBattlenet(p Params) Oauth2Handler {
 func NewMicrosoft(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
 		name:     "microsoft",
-		endpoint: microsoft.AzureADEndpoint("consumers"),
+		endpoint: microsoft.AzureADEndpoint("common"),
 		scopes:   []string{"User.Read"},
 		infoURL:  "https://graph.microsoft.com/v1.0/me",
 		// non-beta doesn't provide photo for consumers yet


### PR DESCRIPTION
The tenant for microsoft.AzureADEndpoint is currently "consumers".  As per
the
[documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints),
this allows only users with personal Microsoft accounts (MSA) to sign
into the application.  Change it to "common" in order to allow users
with both personal Microsoft accounts and work/school accounts from
Azure AD to sign into the application.

Fixes #106