### PR TITLE
fix _example with CustomProvider on go-auth2/oauth2 server

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -294,7 +294,7 @@ func initGoauth2Srv() *goauth2.Server {
 	err := clientStore.Set("cid", &models.Client{
 		ID:     "cid",
 		Secret: "csecret",
-		Domain: "http://127.0.0.1:8080",
+		Domain: "http://localhost:8080",
 	})
 	if err != nil {
 		log.Printf("failed to set up a client store for go-oauth2/oauth2 server, %s", err)


### PR DESCRIPTION
The check below fails in _example because in auth options URL defined as `http://localhost:8080`.  It should match. 
https://github.com/go-oauth2/oauth2/blob/c121ece09e9d992ed7c2e5eda4b2cd3120b9ad6e/manage/util.go#L16

#29 