### PR TITLE
sanitize both user and address in verified provider

### DIFF
--- a/provider/custom_server.go
+++ b/provider/custom_server.go
@@ -3,12 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	goauth2 "github.com/go-oauth2/oauth2/v4/server"

--- a/provider/dev_provider.go
+++ b/provider/dev_provider.go
@@ -3,10 +3,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"net/http"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"golang.org/x/oauth2"

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -216,10 +216,10 @@ func (e VerifyHandler) sanitize(inp string) string {
 	p := bluemonday.UGCPolicy()
 	res := p.Sanitize(inp)
 	res = template.HTMLEscapeString(res)
-	res = strings.Replace(res, "&amp;", "&", -1)
-	res = strings.Replace(res, "&#34;", "\"", -1)
-	res = strings.Replace(res, "&#39;", "'", -1)
-	res = strings.Replace(res, "\n", "", -1)
+	res = strings.ReplaceAll(res, "&amp;", "&")
+	res = strings.ReplaceAll(res, "&#34;", "\"")
+	res = strings.ReplaceAll(res, "&#39;", "'")
+	res = strings.ReplaceAll(res, "\n", "")
 	res = strings.TrimSpace(res)
 	if len(res) > 128 {
 		return res[:128]

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -221,5 +221,8 @@ func (e VerifyHandler) sanitize(inp string) string {
 	res = strings.Replace(res, "&#39;", "'", -1)
 	res = strings.Replace(res, "\n", "", -1)
 	res = strings.TrimSpace(res)
+	if len(res) > 128 {
+		return res[:128]
+	}
 	return res
 }

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -150,7 +150,7 @@ func (e VerifyHandler) sendConfirmation(w http.ResponseWriter, r *http.Request) 
 		},
 		SessionOnly: r.URL.Query().Get("session") != "" && r.URL.Query().Get("session") != "0",
 		StandardClaims: jwt.StandardClaims{
-			Audience:  r.URL.Query().Get("site"),
+			Audience:  e.sanitize(r.URL.Query().Get("site")),
 			ExpiresAt: time.Now().Add(30 * time.Minute).Unix(),
 			NotBefore: time.Now().Add(-1 * time.Minute).Unix(),
 			Issuer:    e.Issuer,

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
+	"html/template"
 	"net/http"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/go-pkgz/rest"

--- a/provider/verify_test.go
+++ b/provider/verify_test.go
@@ -83,13 +83,13 @@ func TestVerifyHandler_LoginSendConfirmRejected(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, 200, rr.Code)
 	assert.Equal(t, "blah@user.com", emailer.to)
-	assert.Contains(t, emailer.text, "&lt;/div&gt; blah@user.com remark42 token:")
+	assert.Contains(t, emailer.text, "Password :    blah@user.com remark42 token:")
 
 	tknStr := strings.Split(emailer.text, " token:")[1]
 	tkn, err := e.TokenService.Parse(tknStr)
 	assert.NoError(t, err)
 	t.Logf("%s %+v", tknStr, tkn)
-	assert.Equal(t, "&lt;h1&gt; Student Login Form &lt;/h1&gt;              &lt;div&gt;             Username :                          Password :                          Login              Remember me              Cancel             Forgot  password?          &lt;/div&gt;::blah@user.com", tkn.Handshake.ID)
+	assert.Equal(t, "&lt;h1&gt; Student Login Form &lt;/h1&gt;              &lt;div&gt;             Username :                          Password :   ::blah@user.com", tkn.Handshake.ID)
 	assert.Equal(t, "remark42", tkn.Audience)
 	assert.True(t, tkn.ExpiresAt > tkn.NotBefore)
 

--- a/provider/verify_test.go
+++ b/provider/verify_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-pkgz/auth/token"
 )
 
-//nolint
+// nolint
 var (
 	testConfirmedToken      = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZW1hcms0MiIsImV4cCI6MTg2MDMwNzQxMiwibmJmIjoxNTYwMzA1NTUyLCJoYW5kc2hha2UiOnsiaWQiOiJ0ZXN0MTIzOjpibGFoQHVzZXIuY29tIn19.D8AvAunK7Tj-P6P56VyaoZ-hyA6U8duZ9HV8-ACEya8`
 	testConfirmedBadIDToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZW1hcms0MiIsImV4cCI6MTg2MDMwNzQxMiwibmJmIjoxNTYwMzA1NTUyLCJoYW5kc2hha2UiOnsiaWQiOiJibGFoQHVzZXIuY29tIn19.hB91-kyY9-Q2Ln6IJGR9StQi-QQiXYu8SV31YhOoTbc`
@@ -53,6 +53,43 @@ func TestVerifyHandler_LoginSendConfirm(t *testing.T) {
 	assert.NoError(t, err)
 	t.Logf("%s %+v", tknStr, tkn)
 	assert.Equal(t, "test123::blah@user.com", tkn.Handshake.ID)
+	assert.Equal(t, "remark42", tkn.Audience)
+	assert.True(t, tkn.ExpiresAt > tkn.NotBefore)
+
+	assert.Equal(t, "test", e.Name())
+}
+
+func TestVerifyHandler_LoginSendConfirmRejected(t *testing.T) {
+
+	emailer := mockSender{}
+	e := VerifyHandler{
+		ProviderName: "test",
+		TokenService: token.NewService(token.Opts{
+			SecretReader:   token.SecretFunc(func(string) (string, error) { return "secret", nil }),
+			TokenDuration:  time.Hour,
+			CookieDuration: time.Hour * 24 * 31,
+		}),
+		Issuer:   "iss-test",
+		L:        logger.Std,
+		Sender:   SenderFunc(emailer.Send),
+		Template: "{{.User}} {{.Address}} {{.Site}} token:{{.Token}}",
+	}
+
+	handler := http.HandlerFunc(e.LoginHandler)
+	rr := httptest.NewRecorder()
+	badUser := "%3C%21DOCTYPE%20html%3E%20%0A%3Chtml%3E%20%0A%3Chead%3E%0A%3Cmeta%20name%3D%22viewport%22%20content%3D%22width%3Ddevice-width%2C%20initial-scale%3D1%22%3E%0A%3Ctitle%3E%20Login%20Page%20%3C%2Ftitle%3E%0A%3Cstyle%3E%20%0ABody%20%7B%0A%20%20font-family%3A%20Calibri%2C%20Helvetica%2C%20sans-serif%3B%0A%20%20background-color%3A%20pink%3B%0A%7D%0Abutton%20%7B%20%0A%20%20%20%20%20%20%20background-color%3A%20%234CAF50%3B%20%0A%20%20%20%20%20%20%20width%3A%20100%25%3B%0A%20%20%20%20%20%20%20%20color%3A%20orange%3B%20%0A%20%20%20%20%20%20%20%20padding%3A%2015px%3B%20%0A%20%20%20%20%20%20%20%20margin%3A%2010px%200px%3B%20%0A%20%20%20%20%20%20%20%20border%3A%20none%3B%20%0A%20%20%20%20%20%20%20%20cursor%3A%20pointer%3B%20%0A%20%20%20%20%20%20%20%20%20%7D%20%0A%20form%20%7B%20%0A%20%20%20%20%20%20%20%20border%3A%203px%20solid%20%23f1f1f1%3B%20%0A%20%20%20%20%7D%20%0A%20input%5Btype%3Dtext%5D%2C%20input%5Btype%3Dpassword%5D%20%7B%20%0A%20%20%20%20%20%20%20%20width%3A%20100%25%3B%20%0A%20%20%20%20%20%20%20%20margin%3A%208px%200%3B%0A%20%20%20%20%20%20%20%20padding%3A%2012px%2020px%3B%20%0A%20%20%20%20%20%20%20%20display%3A%20inline-block%3B%20%0A%20%20%20%20%20%20%20%20border%3A%202px%20solid%20green%3B%20%0A%20%20%20%20%20%20%20%20box-sizing%3A%20border-box%3B%20%0A%20%20%20%20%7D%0A%20button%3Ahover%20%7B%20%0A%20%20%20%20%20%20%20%20opacity%3A%200.7%3B%20%0A%20%20%20%20%7D%20%0A%20%20.cancelbtn%20%7B%20%0A%20%20%20%20%20%20%20%20width%3A%20auto%3B%20%0A%20%20%20%20%20%20%20%20padding%3A%2010px%2018px%3B%0A%20%20%20%20%20%20%20%20margin%3A%2010px%205px%3B%0A%20%20%20%20%7D%20%0A%20%20%20%20%20%20%0A%20%20%20%0A%20.container%20%7B%20%0A%20%20%20%20%20%20%20%20padding%3A%2025px%3B%20%0A%20%20%20%20%20%20%20%20background-color%3A%20lightblue%3B%0A%20%20%20%20%7D%20%0A%3C%2Fstyle%3E%20%0A%3C%2Fhead%3E%20%20%0A%3Cbody%3E%20%20%0A%20%20%20%20%3Ccenter%3E%20%3Ch1%3E%20Student%20Login%20Form%20%3C%2Fh1%3E%20%3C%2Fcenter%3E%20%0A%20%20%20%20%3Cform%3E%0A%20%20%20%20%20%20%20%20%3Cdiv%20class%3D%22container%22%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Clabel%3EUsername%20%3A%20%3C%2Flabel%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cinput%20type%3D%22text%22%20placeholder%3D%22Enter%20Username%22%20name%3D%22username%22%20required%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Clabel%3EPassword%20%3A%20%3C%2Flabel%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cinput%20type%3D%22password%22%20placeholder%3D%22Enter%20Password%22%20name%3D%22password%22%20required%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%20type%3D%22submit%22%3ELogin%3C%2Fbutton%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cinput%20type%3D%22checkbox%22%20checked%3D%22checked%22%3E%20Remember%20me%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22cancelbtn%22%3E%20Cancel%3C%2Fbutton%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20Forgot%20%3Ca%20href%3D%22%23%22%3E%20password%3F%20%3C%2Fa%3E%20%0A%20%20%20%20%20%20%20%20%3C%2Fdiv%3E%20%0A%20%20%20%20%3C%2Fform%3E%20%20%20%0A%3C%2Fbody%3E%20%20%20%0A%3C%2Fhtml%3E%0A%0A%20%0A"
+	req, err := http.NewRequest("GET", "/login?address=blah@user.com&user="+badUser+"&site=remark42", http.NoBody)
+	require.NoError(t, err)
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, "blah@user.com", emailer.to)
+	assert.Contains(t, emailer.text, "&lt;/div&gt; blah@user.com remark42 token:")
+
+	tknStr := strings.Split(emailer.text, " token:")[1]
+	tkn, err := e.TokenService.Parse(tknStr)
+	assert.NoError(t, err)
+	t.Logf("%s %+v", tknStr, tkn)
+	assert.Equal(t, "&lt;h1&gt; Student Login Form &lt;/h1&gt;              &lt;div&gt;             Username :                          Password :                          Login              Remember me              Cancel             Forgot  password?          &lt;/div&gt;::blah@user.com", tkn.Handshake.ID)
 	assert.Equal(t, "remark42", tkn.Audience)
 	assert.True(t, tkn.ExpiresAt > tkn.NotBefore)
 


### PR DESCRIPTION
this PR sanitizes both user and address prior to confirmation callback.

This was done to prevent untrusted user input to set those fields (mostly user) to something we may send, for example, as an email. I'm not sure if an email's HTML can be attacked with injected JS, but either way, it prevents malicious attempts to make fake emails with rich content

@paskal - this is the provider you are familiar with and we usually use it for email logins. Pls take a look
