### PR TITLE
Support OpenID tokens for getting using information

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -274,6 +274,19 @@ func (s *Service) AddDevProvider(port int) {
 		AvatarSaver: s.avatarProxy,
 		L:           s.logger,
 		Port:        port,
+	}
+	s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))
+}
+
+// AddDevOpenIDProvider with a custom port that is service and using OpenID tokens
+func (s *Service) AddDevOpenIDProvider(port int) {
+	p := provider.Params{
+		URL:         s.opts.URL,
+		JwtService:  s.jwtService,
+		Issuer:      s.issuer,
+		AvatarSaver: s.avatarProxy,
+		L:           s.logger,
+		Port:        port,
 		UseOpenID:   true,
 	}
 	s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))

--- a/auth.go
+++ b/auth.go
@@ -315,6 +315,23 @@ func (s *Service) AddCustomProvider(name string, client Client, copts provider.C
 	s.authMiddleware.Providers = s.providers
 }
 
+// AddCustomOpenIDProvider adds custom provider (e.g. https://gopkg.in/oauth2.v3) that uses OpenID instead of pure OAuth2
+func (s *Service) AddCustomOpenIDProvider(name string, client Client, copts provider.CustomHandlerOpt) {
+	p := provider.Params{
+		URL:         s.opts.URL,
+		JwtService:  s.jwtService,
+		Issuer:      s.issuer,
+		AvatarSaver: s.avatarProxy,
+		Cid:         client.Cid,
+		Csecret:     client.Csecret,
+		L:           s.logger,
+		UseOpenID:   true,
+	}
+
+	s.providers = append(s.providers, provider.NewService(provider.NewCustom(name, p, copts)))
+	s.authMiddleware.Providers = s.providers
+}
+
 // AddDirectProvider adds provider with direct check against data store
 // it doesn't do any handshake and uses provided credChecker to verify user and password from the request
 func (s *Service) AddDirectProvider(name string, credChecker provider.CredChecker) {

--- a/auth.go
+++ b/auth.go
@@ -218,9 +218,16 @@ func (s *Service) Middleware() middleware.Authenticator {
 	return s.authMiddleware
 }
 
+func (s *Service) AddOpenIDProvider(name, cid, csecret string) {
+	s.addProvider(name, cid, csecret, true)
+}
+
 // AddProvider adds provider for given name
 func (s *Service) AddProvider(name, cid, csecret string) {
+	s.addProvider(name, cid, csecret, false)
+}
 
+func (s *Service) addProvider(name, cid, csecret string, useOpenID bool) {
 	p := provider.Params{
 		URL:         s.opts.URL,
 		JwtService:  s.jwtService,
@@ -229,6 +236,7 @@ func (s *Service) AddProvider(name, cid, csecret string) {
 		Cid:         cid,
 		Csecret:     csecret,
 		L:           s.logger,
+		UseOpenID:   useOpenID,
 	}
 
 	switch strings.ToLower(name) {
@@ -266,6 +274,7 @@ func (s *Service) AddDevProvider(port int) {
 		AvatarSaver: s.avatarProxy,
 		L:           s.logger,
 		Port:        port,
+		UseOpenID:   true,
 	}
 	s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))
 }

--- a/auth.go
+++ b/auth.go
@@ -269,7 +269,7 @@ func (s *Service) AddDevProvider(port int) {
 	s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))
 }
 
-// AddDevOpenIDProvider with a custom port that is service and using OpenID tokens
+// AddDevOpenIDProvider with a custom port that is using OpenID tokens
 func (s *Service) AddDevOpenIDProvider(port int) {
 	p := provider.Params{
 		URL:         s.opts.URL,

--- a/auth.go
+++ b/auth.go
@@ -218,16 +218,8 @@ func (s *Service) Middleware() middleware.Authenticator {
 	return s.authMiddleware
 }
 
-func (s *Service) AddOpenIDProvider(name, cid, csecret string) {
-	s.addProvider(name, cid, csecret, true)
-}
-
 // AddProvider adds provider for given name
 func (s *Service) AddProvider(name, cid, csecret string) {
-	s.addProvider(name, cid, csecret, false)
-}
-
-func (s *Service) addProvider(name, cid, csecret string, useOpenID bool) {
 	p := provider.Params{
 		URL:         s.opts.URL,
 		JwtService:  s.jwtService,
@@ -236,7 +228,6 @@ func (s *Service) addProvider(name, cid, csecret string, useOpenID bool) {
 		Cid:         cid,
 		Csecret:     csecret,
 		L:           s.logger,
-		UseOpenID:   useOpenID,
 	}
 
 	switch strings.ToLower(name) {
@@ -328,8 +319,8 @@ func (s *Service) AddCustomProvider(name string, client Client, copts provider.C
 	s.authMiddleware.Providers = s.providers
 }
 
-// AddCustomOpenIDProvider adds custom provider (e.g. https://gopkg.in/oauth2.v3) that uses OpenID instead of pure OAuth2
-func (s *Service) AddCustomOpenIDProvider(name string, client Client, copts provider.CustomHandlerOpt) {
+// AddOpenIDProvider adds custom provider (e.g. https://gopkg.in/oauth2.v3) that uses OpenID instead of pure OAuth2
+func (s *Service) AddOpenIDProvider(name string, client Client, copts provider.CustomHandlerOpt) {
 	p := provider.Params{
 		URL:         s.opts.URL,
 		JwtService:  s.jwtService,
@@ -339,6 +330,10 @@ func (s *Service) AddCustomOpenIDProvider(name string, client Client, copts prov
 		Csecret:     client.Csecret,
 		L:           s.logger,
 		UseOpenID:   true,
+	}
+
+	if copts.Scopes == nil {
+		copts.Scopes = []string{"openid"}
 	}
 
 	s.providers = append(s.providers, provider.NewService(provider.NewCustom(name, p, copts)))

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,11 @@ require (
 
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
+	github.com/MicahParks/keyfunc v1.1.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/MicahParks/keyfunc v1.1.0 h1:9NcnRwS0ciuVeVNi+vTdYVMTmk62OID7VlG6y9BgLK0=
+github.com/MicahParks/keyfunc v1.1.0/go.mod h1:a4yfunv77gZ0RgTNw7tOYS+bjtHk5565e+1dPz+YJI8=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
@@ -115,6 +117,8 @@ github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
+github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/provider/custom_server.go
+++ b/provider/custom_server.go
@@ -24,6 +24,7 @@ import (
 type CustomHandlerOpt struct {
 	Endpoint  oauth2.Endpoint
 	InfoURL   string
+	JwksURL   string
 	MapUserFn func(UserData, []byte) token.User
 	Scopes    []string
 }
@@ -208,6 +209,7 @@ func NewCustom(name string, p Params, copts CustomHandlerOpt) Oauth2Handler {
 		endpoint: copts.Endpoint,
 		scopes:   copts.Scopes,
 		infoURL:  copts.InfoURL,
+		jwksURL:  copts.JwksURL,
 		mapUser:  copts.MapUserFn,
 	})
 }

--- a/provider/dev_provider.go
+++ b/provider/dev_provider.go
@@ -94,11 +94,6 @@ func (d *DevAuthServer) Run(ctx context.Context) { //nolint (gocyclo)
 				w.WriteHeader(http.StatusFound)
 
 			case strings.HasPrefix(r.URL.Path, "/login/oauth/access_token"):
-				email := d.username
-				if d.GetEmailFn != nil {
-					email = d.GetEmailFn(d.username)
-				}
-
 				res := `{
 					"access_token":"MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3",
 					"token_type":"bearer",
@@ -109,6 +104,11 @@ func (d *DevAuthServer) Run(ctx context.Context) { //nolint (gocyclo)
 				}`
 
 				if d.Provider.UseOpenID {
+					email := d.username
+					if d.GetEmailFn != nil {
+						email = d.GetEmailFn(d.username)
+					}
+
 					idClaims := map[string]interface{}{
 						// required OpenID claims
 						"iss": "dev-auth",
@@ -255,10 +255,6 @@ func (d *DevAuthServer) Shutdown() {
 	}
 	d.Logf("[DEBUG] shutdown dev oauth2 server completed")
 	d.lock.Unlock()
-}
-
-func (d *DevAuthServer) ParseToken(value string) (claims token.Claims, err error) {
-	return d.Provider.JwtService.Parse(value)
 }
 
 // NewDev makes dev oauth2 provider for admin user

--- a/provider/dev_provider.go
+++ b/provider/dev_provider.go
@@ -2,8 +2,14 @@ package provider
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"github.com/golang-jwt/jwt"
 	"html/template"
+	"math/big"
 	"net/http"
 	"strings"
 	"sync"
@@ -25,9 +31,10 @@ const defDevAuthPort = 8084
 // desired user name, this is the mode used for development. Non-interactive mode for tests only.
 type DevAuthServer struct {
 	logger.L
-	Provider   Oauth2Handler
-	Automatic  bool
-	GetEmailFn func(string) string
+	Provider           Oauth2Handler
+	Automatic          bool
+	GetEmailFn         func(string) string
+	CustomizeIdTokenFn func(map[string]interface{}) map[string]interface{}
 
 	username   string // unsafe, but fine for dev
 	httpServer *http.Server
@@ -47,6 +54,12 @@ func (d *DevAuthServer) Run(ctx context.Context) { //nolint (gocyclo)
 	userFormTmpl, err := template.New("page").Parse(devUserFormTmpl)
 	if err != nil {
 		d.Logf("[WARN] can't parse user form template, %s", err)
+		return
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		d.Logf("[ERROR] failed to generate keys")
 		return
 	}
 
@@ -74,24 +87,95 @@ func (d *DevAuthServer) Run(ctx context.Context) { //nolint (gocyclo)
 				}
 
 				state := r.URL.Query().Get("state")
-				callbackURL := fmt.Sprintf("%s?code=g0ZGZmNjVmOWI&state=%s", d.Provider.conf.RedirectURL, state)
+				redirectURI := r.URL.Query().Get("redirect_uri")
+				callbackURL := fmt.Sprintf("%s?code=g0ZGZmNjVmOWI&state=%s", redirectURI, state)
 				d.Logf("[DEBUG] callback url=%s", callbackURL)
 				w.Header().Add("Location", callbackURL)
 				w.WriteHeader(http.StatusFound)
 
 			case strings.HasPrefix(r.URL.Path, "/login/oauth/access_token"):
-				res := `{
+				email := d.username
+				if d.GetEmailFn != nil {
+					email = d.GetEmailFn(d.username)
+				}
+
+				idClaims := map[string]interface{}{
+					// required OpenID claims
+					"iss": "dev-auth",
+					"sub": "%s",
+					"aud": "client-id",
+					"iat": time.Now().Unix(),
+					"exp": time.Now().Add(1 * time.Hour).Unix(),
+
+					// optional OpenID claims
+					"picture":    fmt.Sprintf("http://127.0.0.1:%d/avatar?user=%s", d.Provider.Port, d.username),
+					"given_name": d.username,
+					"email":      email,
+				}
+
+				if d.CustomizeIdTokenFn != nil {
+					idClaims = d.CustomizeIdTokenFn(idClaims)
+				}
+
+				tk := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(idClaims))
+				tk.Header["kid"] = "dev-auth-key-1"
+				signedTk, err := tk.SignedString(privateKey)
+				if err != nil {
+					d.Logf("[ERROR] failed to sign ID token")
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+
+				res := fmt.Sprintf(`{
 					"access_token":"MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3",
+					"id_token": "%s",
 					"token_type":"bearer",
 					"expires_in":3600,
 					"refresh_token":"IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk",
 					"scope":"create",
 					"state":"12345678"
-					}`
+					}`, signedTk)
+
 				w.Header().Set("Content-Type", "application/json; charset=utf-8")
 				if _, err = w.Write([]byte(res)); err != nil {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
+				}
+
+			case strings.HasPrefix(r.URL.Path, "/jwks"):
+				type jwkKey struct {
+					Kty string `json:"kty"`
+					N   string `json:"n"`
+					E   string `json:"e"`
+					Alg string `json:"alg"`
+					Kid string `json:"kid"`
+				}
+
+				e := big.NewInt(int64(privateKey.E))
+				key := jwkKey{
+					Kty: "RSA",
+					Alg: "RS256",
+					Kid: "dev-auth-key-1",
+					N:   base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes()),
+					E:   base64.RawURLEncoding.EncodeToString(e.Bytes()),
+				}
+
+				jwks, err := json.Marshal(struct {
+					Keys []jwkKey `json:"keys"`
+				}{
+					Keys: []jwkKey{key},
+				})
+				if err != nil {
+					d.Logf("[ERROR] failed to marshal jwks")
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+
+				w.WriteHeader(http.StatusOK)
+				wr, err := w.Write(jwks)
+				if err != nil || wr == 0 {
+					d.Logf("[ERROR] failed to write jwks")
+					w.WriteHeader(http.StatusInternalServerError)
 				}
 
 			case strings.HasPrefix(r.URL.Path, "/user"):
@@ -162,6 +246,10 @@ func (d *DevAuthServer) Shutdown() {
 	d.lock.Unlock()
 }
 
+func (d *DevAuthServer) ParseToken(value string) (claims token.Claims, err error) {
+	return d.Provider.JwtService.Parse(value)
+}
+
 // NewDev makes dev oauth2 provider for admin user
 func NewDev(p Params) Oauth2Handler {
 	if p.Port == 0 {
@@ -175,14 +263,23 @@ func NewDev(p Params) Oauth2Handler {
 		},
 		scopes:  []string{"user:email"},
 		infoURL: fmt.Sprintf("http://127.0.0.1:%d/user", p.Port),
+		jwksURL: fmt.Sprintf("http://127.0.0.1:%d/jwks", p.Port),
 		mapUser: func(data UserData, _ []byte) token.User {
-			userInfo := token.User{
+			if p.UseOpenID {
+				return token.User{
+					ID:      data.Value("sub"),
+					Name:    data.Value("given_name"),
+					Picture: data.Value("picture"),
+					Email:   data.Value("email"),
+				}
+			}
+
+			return token.User{
 				ID:      data.Value("id"),
 				Name:    data.Value("name"),
 				Picture: data.Value("picture"),
 				Email:   data.Value("email"),
 			}
-			return userInfo
 		},
 	})
 

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -213,7 +213,7 @@ func TestMakeRedirURL(t *testing.T) {
 	for i := range cases {
 		c := cases[i]
 		oh := initOauth2Handler(Params{URL: c.rootURL}, Oauth2Handler{})
-		assert.Equal(t, c.out, oh.makeRedirURLFromPath(c.route))
+		assert.Equal(t, c.out, oh.makeRedirURL(c.route))
 	}
 }
 

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -213,12 +213,11 @@ func TestMakeRedirURL(t *testing.T) {
 	for i := range cases {
 		c := cases[i]
 		oh := initOauth2Handler(Params{URL: c.rootURL}, Oauth2Handler{})
-		assert.Equal(t, c.out, oh.makeRedirURL(c.route))
+		assert.Equal(t, c.out, oh.makeRedirURLFromPath(c.route))
 	}
 }
 
 func prepOauth2Test(t *testing.T, loginPort, authPort int) func() {
-
 	provider := Oauth2Handler{
 		name: "mock",
 		endpoint: oauth2.Endpoint{

--- a/provider/openid_test.go
+++ b/provider/openid_test.go
@@ -1,0 +1,90 @@
+package provider_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-pkgz/auth"
+	"github.com/go-pkgz/auth/avatar"
+	"github.com/go-pkgz/auth/logger"
+	"github.com/go-pkgz/auth/provider"
+	"github.com/go-pkgz/auth/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewOpenID(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	devPort := rand.Intn(10_000) + 50_000
+	expectedTestUserSub := fmt.Sprintf("test-user-%d", devPort)
+	svc := auth.NewService(auth.Opts{
+		SecretReader: token.SecretFunc(func(aud string) (string, error) {
+			return "some-signing-key", nil
+		}),
+		Logger:      logger.Std,
+		AvatarStore: avatar.NewNoOp(),
+	})
+
+	devParams := provider.Params{
+		L:           logger.Std,
+		URL:         fmt.Sprintf("http://localhost:%d", devPort),
+		JwtService:  svc.TokenService(),
+		Cid:         "client-id",
+		Csecret:     "client-secret",
+		Issuer:      "test-issuer",
+		AvatarSaver: svc.AvatarProxy(),
+		UseOpenID:   true,
+		Port:        devPort,
+	}
+
+	dev := provider.NewDev(devParams)
+	devAuth := &provider.DevAuthServer{Provider: dev, L: logger.Std}
+	devAuth.Automatic = true
+	devAuth.CustomizeIdTokenFn = func(m map[string]interface{}) map[string]interface{} {
+		m["sub"] = expectedTestUserSub
+		return m
+	}
+
+	go devAuth.Run(context.Background())
+	defer devAuth.Shutdown()
+
+	time.Sleep(300 * time.Millisecond)
+
+	svc.AddDevProvider(devPort)
+
+	authHandler, _ := svc.Handlers()
+	server := httptest.NewServer(authHandler)
+	defer server.Close()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	client := http.Client{
+		Jar: jar,
+	}
+
+	resp, err := client.Get(server.URL + "/auth/dev/login")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	cookies := resp.Cookies()
+	var cookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "JWT" {
+			cookie = c
+			break
+		}
+	}
+
+	require.NotNil(t, cookie)
+	claims, err := devAuth.ParseToken(cookie.Value)
+	require.NoError(t, err)
+
+	// check user details are from the ID token
+	assert.Equal(t, expectedTestUserSub, claims.User.ID)
+}


### PR DESCRIPTION
Some providers (e.g. Cognito) provide only minimal subset of user attributes in `/userinfo` endpoint, but much more in the ID tokens. That can be helpful to pass user metadata from the provider to the app. This PR adds support of OpenID tokens as a source of user info, as an extension to the OAuth2 flow. 

OpenID flow is only supported for custom providers at the moment and require JWKS URL configuration. Switching existing providers (e.g. `google`) to OpenID is TBD, but probably not required. Using OpenID Connect (`.well-known/openid-configuration` URLs) is out of scope for this PR. 

Apple flow basically is OpenID, with some customisations on how client secret is passed across. So potentially these two flows can be merged together later on.