### PR TITLE
Remove unused mockery call, regenerate moq

### DIFF
--- a/avatar/store.go
+++ b/avatar/store.go
@@ -1,7 +1,5 @@
 package avatar
 
-//go:generate sh -c "mockery -inpkg -name Store -print > /tmp/mock.tmp && mv /tmp/mock.tmp store_mock.go"
-
 import (
 	"context"
 	"crypto/sha1" //nolint gosec

--- a/provider/telegram.go
+++ b/provider/telegram.go
@@ -1,6 +1,6 @@
 package provider
 
-//go:generate moq -out telegram_moq_test.go . TelegramAPI
+//go:generate moq --out telegram_moq_test.go . TelegramAPI
 
 import (
 	"context"

--- a/provider/telegram_moq_test.go
+++ b/provider/telegram_moq_test.go
@@ -14,28 +14,28 @@ var _ TelegramAPI = &TelegramAPIMock{}
 
 // TelegramAPIMock is a mock implementation of TelegramAPI.
 //
-//     func TestSomethingThatUsesTelegramAPI(t *testing.T) {
+//	func TestSomethingThatUsesTelegramAPI(t *testing.T) {
 //
-//         // make and configure a mocked TelegramAPI
-//         mockedTelegramAPI := &TelegramAPIMock{
-//             AvatarFunc: func(ctx context.Context, userID int) (string, error) {
-// 	               panic("mock out the Avatar method")
-//             },
-//             BotInfoFunc: func(ctx context.Context) (*botInfo, error) {
-// 	               panic("mock out the BotInfo method")
-//             },
-//             GetUpdatesFunc: func(ctx context.Context) (*telegramUpdate, error) {
-// 	               panic("mock out the GetUpdates method")
-//             },
-//             SendFunc: func(ctx context.Context, id int, text string) error {
-// 	               panic("mock out the Send method")
-//             },
-//         }
+//		// make and configure a mocked TelegramAPI
+//		mockedTelegramAPI := &TelegramAPIMock{
+//			AvatarFunc: func(ctx context.Context, userID int) (string, error) {
+//				panic("mock out the Avatar method")
+//			},
+//			BotInfoFunc: func(ctx context.Context) (*botInfo, error) {
+//				panic("mock out the BotInfo method")
+//			},
+//			GetUpdatesFunc: func(ctx context.Context) (*telegramUpdate, error) {
+//				panic("mock out the GetUpdates method")
+//			},
+//			SendFunc: func(ctx context.Context, id int, text string) error {
+//				panic("mock out the Send method")
+//			},
+//		}
 //
-//         // use mockedTelegramAPI in code that requires TelegramAPI
-//         // and then make assertions.
+//		// use mockedTelegramAPI in code that requires TelegramAPI
+//		// and then make assertions.
 //
-//     }
+//	}
 type TelegramAPIMock struct {
 	// AvatarFunc mocks the Avatar method.
 	AvatarFunc func(ctx context.Context, userID int) (string, error)
@@ -104,7 +104,8 @@ func (mock *TelegramAPIMock) Avatar(ctx context.Context, userID int) (string, er
 
 // AvatarCalls gets all the calls that were made to Avatar.
 // Check the length with:
-//     len(mockedTelegramAPI.AvatarCalls())
+//
+//	len(mockedTelegramAPI.AvatarCalls())
 func (mock *TelegramAPIMock) AvatarCalls() []struct {
 	Ctx    context.Context
 	UserID int
@@ -137,7 +138,8 @@ func (mock *TelegramAPIMock) BotInfo(ctx context.Context) (*botInfo, error) {
 
 // BotInfoCalls gets all the calls that were made to BotInfo.
 // Check the length with:
-//     len(mockedTelegramAPI.BotInfoCalls())
+//
+//	len(mockedTelegramAPI.BotInfoCalls())
 func (mock *TelegramAPIMock) BotInfoCalls() []struct {
 	Ctx context.Context
 } {
@@ -168,7 +170,8 @@ func (mock *TelegramAPIMock) GetUpdates(ctx context.Context) (*telegramUpdate, e
 
 // GetUpdatesCalls gets all the calls that were made to GetUpdates.
 // Check the length with:
-//     len(mockedTelegramAPI.GetUpdatesCalls())
+//
+//	len(mockedTelegramAPI.GetUpdatesCalls())
 func (mock *TelegramAPIMock) GetUpdatesCalls() []struct {
 	Ctx context.Context
 } {
@@ -203,7 +206,8 @@ func (mock *TelegramAPIMock) Send(ctx context.Context, id int, text string) erro
 
 // SendCalls gets all the calls that were made to Send.
 // Check the length with:
-//     len(mockedTelegramAPI.SendCalls())
+//
+//	len(mockedTelegramAPI.SendCalls())
 func (mock *TelegramAPIMock) SendCalls() []struct {
 	Ctx  context.Context
 	ID   int


### PR DESCRIPTION
Mockery-generated mock was never used in the current code.