### PR TITLE
Use assert.NoError in place of Nil, remove ioutil usage, bump golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           sudo systemctl disable mono-xsp4.service || true
 
       - name: set up go 1.17
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
         id: go
@@ -28,7 +28,7 @@ jobs:
           mongoDBVersion: "4.4"
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: build and test
         run: |
@@ -37,19 +37,18 @@ jobs:
           cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "_mock.go" > $GITHUB_WORKSPACE/profile.cov
           go build -race
         env:
-          GO111MODULE: "on"
           TZ: "America/Chicago"
           ENABLE_MONGO_TESTS: "true"
 
       - name: install golangci-lint and goveralls
         run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.44.0
-          GO111MODULE=off go get -u -v github.com/mattn/goveralls
+          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.50.1
+          go install github.com/mattn/goveralls@latest
 
       - name: run linters
         run: $GITHUB_WORKSPACE/golangci-lint run
 
       - name: submit coverage
-        run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
+        run: goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,17 +29,13 @@ linters:
     - revive
     - govet
     - unconvert
-    - megacheck
-    - structcheck
+    - unused
     - gas
     - gocyclo
     - misspell
     - unparam
-    - varcheck
-    - deadcode
     - typecheck
     - ineffassign
-    - varcheck
     - stylecheck
     - gochecknoinits
     - exportloopref
@@ -65,6 +61,10 @@ issues:
       linters:
         - gosec
     - text: "Use of weak cryptographic primitive"
+      linters:
+        - gosec
+    - path: _test\.go
+      text: "Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server"
       linters:
         - gosec
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -105,7 +104,7 @@ Ivx5tHkv
 -----END PRIVATE KEY-----`
 	testPrivKeyFileName := "privKeyTest.tmp"
 
-	dir, err := ioutil.TempDir(os.TempDir(), testPrivKeyFileName)
+	dir, err := os.MkdirTemp(os.TempDir(), testPrivKeyFileName)
 	assert.NoError(t, err)
 	assert.NotNil(t, dir)
 	if err != nil {
@@ -157,7 +156,7 @@ func TestIntegrationProtected(t *testing.T) {
 	assert.Equal(t, 401, resp.StatusCode)
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "Unauthorized\n", string(body))
 
 	// check non-admin, permanent
@@ -166,7 +165,7 @@ func TestIntegrationProtected(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 	defer resp.Body.Close()
 	body, err = io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
 	require.Equal(t, 2, len(resp.Cookies()))
@@ -355,7 +354,7 @@ func TestDirectProvider(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 
 	body, err := io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
 
@@ -393,7 +392,7 @@ func TestDirectProvider_WithCustomUserIDFunc(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 
 	body, err := io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
 

--- a/avatar/avatar_test.go
+++ b/avatar/avatar_test.go
@@ -227,7 +227,7 @@ func TestAvatar_resize(t *testing.T) {
 		assert.NotNil(t, resizedR, "file %s", c.file)
 
 		imgRz, format, err := image.Decode(resizedR)
-		assert.Nil(t, err, "file %s", c.file)
+		assert.NoError(t, err, "file %s", c.file)
 		assert.Equal(t, "png", format, "file %s", c.file)
 		bounds := imgRz.Bounds()
 		assert.Equal(t, c.wr, bounds.Dx(), "file %s", c.file)
@@ -268,13 +268,13 @@ func TestAvatar_Retry(t *testing.T) {
 		i++
 		return fmt.Errorf("err")
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 3, i)
 
 	st := time.Now()
 	err = retry(5, time.Millisecond, func() error {
 		return fmt.Errorf("err")
 	})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.True(t, time.Since(st) >= time.Microsecond*5)
 }

--- a/avatar/bolt_test.go
+++ b/avatar/bolt_test.go
@@ -31,7 +31,7 @@ func TestBoltDB_PutAndGet(t *testing.T) {
 	assert.Equal(t, "some picture bin data", string(data))
 
 	_, _, err = b.Get("bad avatar")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// check IDs
 	assert.Equal(t, "fddae9ce556712a6ece0e8951a6e7a05c51ed6bf", b.ID(avatar))
@@ -47,13 +47,13 @@ func TestBoltDB_Remove(t *testing.T) {
 	b, teardown := prepBoltStore(t)
 	defer teardown()
 
-	assert.NotNil(t, b.Remove("no-such-thing.image"))
+	assert.Error(t, b.Remove("no-such-thing.image"))
 
 	avatar, err := b.Put("user1", strings.NewReader("some picture bin data"))
 	require.Nil(t, err)
 	assert.Equal(t, "b3daa77b4c04a9551b8781d03191fe098f325e67.image", avatar)
 	assert.NoError(t, b.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "remove real one")
-	assert.NotNil(t, b.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "already removed")
+	assert.Error(t, b.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "already removed")
 }
 
 func TestBoltDB_List(t *testing.T) {
@@ -75,10 +75,10 @@ func TestBoltDB_List(t *testing.T) {
 	assert.Equal(t, []string{"0b7f849446d3383546d15a480966084442cd2193.image", "a1881c06eec96db9901c7bbfe41c42a3f08e9cb4.image", "b3daa77b4c04a9551b8781d03191fe098f325e67.image"}, l)
 
 	r, size, err := b.Get("0b7f849446d3383546d15a480966084442cd2193.image")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 23, size)
 	data, err := io.ReadAll(r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "some picture bin data 3", string(data))
 }
 
@@ -88,7 +88,7 @@ func prepBoltStore(t *testing.T) (blt *BoltDB, teardown func()) {
 	boltStore, err := NewBoltDB(testDB, bolt.Options{})
 	require.Nil(t, err)
 	return boltStore, func() {
-		assert.Nil(t, boltStore.Close())
+		assert.NoError(t, boltStore.Close())
 		_ = os.Remove(testDB)
 	}
 }

--- a/avatar/gridfs.go
+++ b/avatar/gridfs.go
@@ -59,7 +59,6 @@ func (gf *GridFS) Get(avatar string) (reader io.ReadCloser, size int, err error)
 	return io.NopCloser(buf), int(sz), nil
 }
 
-//
 // ID returns a fingerprint of the avatar content. Uses MD5 because gridfs provides it directly
 func (gf *GridFS) ID(avatar string) (id string) {
 

--- a/avatar/gridfs_test.go
+++ b/avatar/gridfs_test.go
@@ -32,7 +32,7 @@ func TestGridFS_PutAndGet(t *testing.T) {
 	assert.Equal(t, "some picture bin data", string(data))
 
 	_, _, err = p.Get("bad avatar")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "fddae9ce556712a6ece0e8951a6e7a05c51ed6bf", p.ID(avatar))
 	assert.Equal(t, "70c881d4a26984ddce795f6f71817c9cf4480e79", p.ID("aaaa"), "no data, encode avatar id")
 
@@ -47,12 +47,12 @@ func TestGridFS_Remove(t *testing.T) {
 		t.Skip("ENABLE_MONGO_TESTS env variable is not set")
 	}
 	p := prepGFStore(t)
-	assert.NotNil(t, p.Remove("no-such-thing.image"))
+	assert.Error(t, p.Remove("no-such-thing.image"))
 	avatar, err := p.Put("user1", strings.NewReader("some picture bin data"))
 	require.Nil(t, err)
 	assert.Equal(t, "b3daa77b4c04a9551b8781d03191fe098f325e67.image", avatar)
 	assert.NoError(t, p.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "remove real one")
-	assert.NotNil(t, p.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "already removed")
+	assert.Error(t, p.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "already removed")
 }
 
 func TestGridFS_List(t *testing.T) {
@@ -76,10 +76,10 @@ func TestGridFS_List(t *testing.T) {
 	assert.Equal(t, []string{"0b7f849446d3383546d15a480966084442cd2193.image", "a1881c06eec96db9901c7bbfe41c42a3f08e9cb4.image", "b3daa77b4c04a9551b8781d03191fe098f325e67.image"}, l)
 
 	r, size, err := p.Get("0b7f849446d3383546d15a480966084442cd2193.image")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 23, size)
 	data, err := io.ReadAll(r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "some picture bin data 3", string(data))
 }
 

--- a/avatar/localfs_test.go
+++ b/avatar/localfs_test.go
@@ -2,7 +2,6 @@ package avatar
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -72,14 +71,14 @@ func TestAvatarStoreFS_Get(t *testing.T) {
 	assert.Equal(t, 0, size)
 	assert.EqualError(t, err, "can't load avatar some_random_name.image, id: open /tmp/avatars.test/91/some_random_name.image: no such file or directory")
 	// file exists
-	err = ioutil.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
-	assert.Nil(t, err)
+	err = os.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
+	assert.NoError(t, err)
 	r, size, err = p.Get("b3daa77b4c04a9551b8781d03191fe098f325e67.image")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 9, size)
 	data, err := io.ReadAll(r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "something", string(data))
 }
 
@@ -111,7 +110,7 @@ func TestAvatarStoreFS_ID(t *testing.T) {
 	id := p.ID("some_random_name.image")
 	assert.Equal(t, "a008de0a2ccb3308b5d99ffff66436e15538f701", id) // "some_random_name.image"
 	// file exists
-	err = ioutil.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
+	err = os.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
 	require.NoError(t, err)
 	touch := time.Date(2017, 7, 14, 2, 40, 0, 0, time.UTC) // 1500000000
 	err = os.Chtimes("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", touch, touch)
@@ -126,13 +125,13 @@ func TestAvatarStoreFS_Remove(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll("/tmp/avatars.test")
 
-	assert.NotNil(t, p.Remove("no-such-avatar"), "remove non-existing avatar")
-	err = ioutil.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
+	assert.Error(t, p.Remove("no-such-avatar"), "remove non-existing avatar")
+	err = os.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
 	require.NoError(t, err)
 
 	assert.NoError(t, p.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"))
 	_, err = os.Stat("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
-	assert.NotNil(t, err, "removed for real")
+	assert.Error(t, err, "removed for real")
 	t.Log(err)
 }
 
@@ -157,10 +156,10 @@ func TestAvatarStoreFS_List(t *testing.T) {
 	assert.Equal(t, []string{"0b7f849446d3383546d15a480966084442cd2193.image", "a1881c06eec96db9901c7bbfe41c42a3f08e9cb4.image", "b3daa77b4c04a9551b8781d03191fe098f325e67.image"}, l)
 
 	r, size, err := p.Get("0b7f849446d3383546d15a480966084442cd2193.image")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 23, size)
 	data, err := io.ReadAll(r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "some picture bin data 3", string(data))
 }
 
@@ -168,7 +167,7 @@ func BenchmarkAvatarStoreFS_ID(b *testing.B) {
 	p := NewLocalFS("/tmp/avatars.test")
 	_ = os.MkdirAll("/tmp/avatars.test/30", 0o700)
 	defer os.RemoveAll("/tmp/avatars.test")
-	err := ioutil.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
+	err := os.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
 	require.NoError(b, err)
 
 	b.ResetTimer()

--- a/avatar/store_test.go
+++ b/avatar/store_test.go
@@ -48,10 +48,10 @@ func TestAvatarStore_Migrate(t *testing.T) {
 
 	// try to read one of migrated avatars
 	r, size, err := pgfs.Get("0b7f849446d3383546d15a480966084442cd2193.image")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 23, size)
 	data, err := io.ReadAll(r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "some picture bin data 3", string(data))
 }
 

--- a/provider/apple_pubkeys_test.go
+++ b/provider/apple_pubkeys_test.go
@@ -121,7 +121,7 @@ func TestAppleKeySet_Get(t *testing.T) {
 	require.Nil(t, err)
 
 	apk, err := testKeySet.get("86D88Kf")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, apk.ID, "86D88Kf")
 
 	_, err = testKeySet.get("not-found-kid")
@@ -165,7 +165,6 @@ func TestAppleKeySet_KeyFunc(t *testing.T) {
 }
 
 func prepareAppleKeysTestServer(t *testing.T, authPort int) func() {
-	//nolint dupl
 	ts := &http.Server{
 		Addr: fmt.Sprintf(":%d", authPort),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/provider/custom_server.go
+++ b/provider/custom_server.go
@@ -88,7 +88,8 @@ func (c *CustomServer) Run(ctx context.Context) {
 	}
 
 	c.httpServer = &http.Server{
-		Addr: fmt.Sprintf(":%s", port),
+		Addr:              fmt.Sprintf(":%s", port),
+		ReadHeaderTimeout: 5 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case strings.HasSuffix(r.URL.Path, "/authorize"):

--- a/provider/custom_server_test.go
+++ b/provider/custom_server_test.go
@@ -85,7 +85,7 @@ func TestCustomProvider(t *testing.T) {
 			assert.NotEqual(t, "", resp.Cookies()[1].Value, "xsrf cookie set")
 
 			claims, err := params.JwtService.Parse(resp.Cookies()[0].Value)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			assert.Equal(t, token.User{Name: "admin", ID: "admin",
 				Picture: "http://127.0.0.1:9096/avatar?user=admin", IP: ""}, *claims.User)
@@ -124,7 +124,7 @@ func TestCustomProvider(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
 
@@ -133,7 +133,7 @@ func TestCustomProvider(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	body, err = io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 960, len(body))
 	t.Logf("headers: %+v", resp.Header)
 

--- a/provider/dev_provider.go
+++ b/provider/dev_provider.go
@@ -57,7 +57,8 @@ func (d *DevAuthServer) Run(ctx context.Context) { // nolint (gocyclo)
 	}
 
 	d.httpServer = &http.Server{
-		Addr: fmt.Sprintf(":%d", d.Provider.Port),
+		Addr:              fmt.Sprintf(":%d", d.Provider.Port),
+		ReadHeaderTimeout: 5 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			d.Logf("[DEBUG] dev oauth request %s %s %+v", r.Method, r.URL, r.Header)
 			switch {

--- a/provider/dev_provider_test.go
+++ b/provider/dev_provider_test.go
@@ -55,7 +55,7 @@ func TestDevProvider(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
 
@@ -67,7 +67,7 @@ func TestDevProvider(t *testing.T) {
 	assert.NotEqual(t, "", resp.Cookies()[1].Value, "xsrf cookie set")
 
 	claims, err := params.JwtService.Parse(resp.Cookies()[0].Value)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, token.User{Name: "dev_user", ID: "dev_user",
 		Picture: "http://127.0.0.1:18084/avatar?user=dev_user", IP: "", Email: "dev_user@example.com"}, *claims.User)
@@ -77,7 +77,7 @@ func TestDevProvider(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	body, err = io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 960, len(body))
 	t.Logf("headers: %+v", resp.Header)
 }

--- a/provider/oauth1_test.go
+++ b/provider/oauth1_test.go
@@ -38,7 +38,7 @@ func TestOauth1Login(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
 
@@ -51,7 +51,7 @@ func TestOauth1Login(t *testing.T) {
 
 	u := token.User{}
 	err = json.Unmarshal(body, &u)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, token.User{Name: "blah", ID: "mock_myuser1", Picture: "http://example.com/custom.png", IP: ""}, u)
 
 	tk := resp.Cookies()[0].Value
@@ -66,13 +66,13 @@ func TestOauth1Login(t *testing.T) {
 
 	// check admin user
 	resp, err = client.Get(fmt.Sprintf("http://localhost:%d/login?site=remark", loginPort))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	body, err = io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	u = token.User{}
 	err = json.Unmarshal(body, &u)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, token.User{Name: "blah", ID: "mock_myuser2", Picture: "http://example.com/ava12345.png",
 		Attributes: map[string]interface{}{"admin": true}}, u)
 

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -37,7 +37,7 @@ func TestOauth2Login(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
 
@@ -50,7 +50,7 @@ func TestOauth2Login(t *testing.T) {
 
 	u := token.User{}
 	err = json.Unmarshal(body, &u)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, token.User{Name: "blah", ID: "mock_myuser1", Picture: "http://example.com/custom.png", IP: ""}, u)
 
 	tk := resp.Cookies()[0].Value
@@ -65,13 +65,13 @@ func TestOauth2Login(t *testing.T) {
 
 	// check admin user
 	resp, err = client.Get("http://localhost:8981/login?site=remark")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	body, err = io.ReadAll(resp.Body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	u = token.User{}
 	err = json.Unmarshal(body, &u)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, token.User{Name: "blah", ID: "mock_myuser2", Picture: "http://example.com/ava12345.png",
 		Attributes: map[string]interface{}{"admin": true}}, u)
 }
@@ -265,7 +265,6 @@ func prepOauth2Test(t *testing.T, loginPort, authPort int) func() {
 	count := 0
 	useIds := []string{"myuser1", "myuser2"} // user for first ans second calls
 
-	//nolint dupl
 	oauth := &http.Server{
 		Addr: fmt.Sprintf(":%d", authPort),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -82,7 +82,7 @@ func TestJWT_Token(t *testing.T) {
 
 	claims := testClaims
 	res, err := j.Token(claims)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, testJwtValid, res)
 
 	j.SecretReader = nil
@@ -120,7 +120,7 @@ func TestJWT_Parse(t *testing.T) {
 	assert.EqualError(t, err, "token is not valid yet")
 
 	_, err = j.Parse("bad")
-	assert.NotNil(t, err, "bad token")
+	assert.Error(t, err, "bad token")
 
 	_, err = j.Parse(testJwtBadSign)
 	assert.EqualError(t, err, "can't parse token: signature is invalid")
@@ -132,7 +132,7 @@ func TestJWT_Parse(t *testing.T) {
 		SecretReader: SecretFunc(func(string) (string, error) { return "bad 12345", nil }),
 	})
 	_, err = j.Parse(testJwtValid)
-	assert.NotNil(t, err, "bad token", "valid token parsed with wrong secret")
+	assert.Error(t, err, "bad token", "valid token parsed with wrong secret")
 
 	j = NewService(Opts{
 		SecretReader: SecretFunc(func(string) (string, error) { return "", fmt.Errorf("err blah") }),
@@ -160,7 +160,7 @@ func TestJWT_Set(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	c, err := j.Set(rr, claims)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, claims, c)
 	cookies := rr.Result().Cookies()
 	t.Log(cookies)
@@ -174,7 +174,7 @@ func TestJWT_Set(t *testing.T) {
 	claims.SessionOnly = true
 	rr = httptest.NewRecorder()
 	_, err = j.Set(rr, claims)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	cookies = rr.Result().Cookies()
 	t.Log(cookies)
 	require.Equal(t, 2, len(cookies))
@@ -188,7 +188,7 @@ func TestJWT_Set(t *testing.T) {
 	j.DisableIAT = false
 	rr = httptest.NewRecorder()
 	_, err = j.Set(rr, claims)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	cookies = rr.Result().Cookies()
 	t.Log(cookies)
 	require.Equal(t, 2, len(cookies))
@@ -215,7 +215,7 @@ func TestJWT_SetWithDomain(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	c, err := j.Set(rr, claims)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, claims, c)
 	cookies := rr.Result().Cookies()
 	t.Log(cookies)
@@ -247,7 +247,7 @@ func TestJWT_SendJWTHeader(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	_, err := j.Set(rr, testClaims)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	cookies := rr.Result().Cookies()
 	t.Log(cookies)
 	require.Equal(t, 0, len(cookies), "no cookies set")
@@ -325,7 +325,7 @@ func TestJWT_GetFromHeader(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Add(jwtCustomHeaderKey, testJwtValid)
 	claims, token, err := j.Get(req)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, testJwtValid, token)
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
@@ -336,7 +336,7 @@ func TestJWT_GetFromHeader(t *testing.T) {
 	req = httptest.NewRequest("GET", "/", nil)
 	req.Header.Add(jwtCustomHeaderKey, testJwtExpired)
 	_, _, err = j.Get(req)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	req = httptest.NewRequest("GET", "/", nil)
 	req.Header.Add(jwtCustomHeaderKey, "bad bad token")
@@ -357,7 +357,7 @@ func TestJWT_GetFromQuery(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/blah?token="+testJwtValid, nil)
 	claims, token, err := j.Get(req)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, testJwtValid, token)
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
@@ -367,7 +367,7 @@ func TestJWT_GetFromQuery(t *testing.T) {
 
 	req = httptest.NewRequest("GET", "/blah?token="+testJwtExpired, nil)
 	_, _, err = j.Get(req)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	req = httptest.NewRequest("GET", "/blah?token=blah", nil)
 	_, _, err = j.Get(req)
@@ -414,7 +414,7 @@ func TestJWT_SetAndGetWithCookies(t *testing.T) {
 	req.AddCookie(resp.Cookies()[0])
 	req.Header.Add(xsrfCustomHeaderKey, "random id")
 	r, _, err := j.Get(req)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
 		Email: "me@example.com", Audience: "test_sys",
 		Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, r.User)
@@ -503,7 +503,7 @@ func TestJWT_SetAndGetWithCookiesExpired(t *testing.T) {
 	req.AddCookie(resp.Cookies()[0])
 	req.Header.Add(xsrfCustomHeaderKey, "random id")
 	r, _, err := j.Get(req)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, j.IsExpired(r))
 }
 
@@ -569,7 +569,7 @@ func TestAudience(t *testing.T) {
 	assert.EqualError(t, err, `aud "au1" not allowed`)
 
 	err = j.checkAuds(&c, AudienceFunc(func() ([]string, error) { return []string{"xxx", "yyy", "au1"}, nil }))
-	assert.Nil(t, err, `au1 allowed`)
+	assert.NoError(t, err, `au1 allowed`)
 }
 
 func TestAudReader(t *testing.T) {

--- a/token/user_test.go
+++ b/token/user_test.go
@@ -100,13 +100,13 @@ func TestUser_PaidSubscriber(t *testing.T) {
 
 func TestUser_GetUserInfo(t *testing.T) {
 	r, err := http.NewRequest("GET", "http://blah.com", http.NoBody)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = GetUserInfo(r)
 	assert.EqualError(t, err, "user can't be parsed")
 
 	r = SetUserInfo(r, User{Name: "test", ID: "id"})
 	u, err := GetUserInfo(r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, User{Name: "test", ID: "id"}, u)
 }
 
@@ -118,12 +118,12 @@ func TestUser_MustGetUserInfo(t *testing.T) {
 	}()
 
 	r, err := http.NewRequest("GET", "http://blah.com", http.NoBody)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_ = MustGetUserInfo(r)
 	assert.Fail(t, "should panic")
 
 	r = SetUserInfo(r, User{Name: "test", ID: "id"})
 	u := MustGetUserInfo(r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, User{Name: "test", ID: "id"}, u)
 }


### PR DESCRIPTION
ioutil is a deprecated module, and `assert.NoError` makes test error messages formatting more clear.

Also, bump golangci-lint and fix the error `G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server`