### PR TITLE
Fix nil ptr panic in auth.go

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -181,11 +181,9 @@ func (s *Service) Handlers() (authHandler, avatarHandler http.Handler) {
 			claims, _, err := s.jwtService.Get(r)
 			if err != nil || claims.User == nil {
 				w.WriteHeader(http.StatusUnauthorized)
-				var msg string
+				msg := "user is nil"
 				if err != nil {
 					msg = err.Error()
-				} else {
-					msg = "User is nil"
 				}
 				rest.RenderJSON(w, rest.JSON{"error": msg})
 				return

--- a/auth.go
+++ b/auth.go
@@ -181,7 +181,13 @@ func (s *Service) Handlers() (authHandler, avatarHandler http.Handler) {
 			claims, _, err := s.jwtService.Get(r)
 			if err != nil || claims.User == nil {
 				w.WriteHeader(http.StatusUnauthorized)
-				rest.RenderJSON(w, rest.JSON{"error": err.Error()})
+				var msg string
+				if err != nil {
+					msg = err.Error()
+				} else {
+					msg = "User is nil"
+				}
+				rest.RenderJSON(w, rest.JSON{"error": msg})
 				return
 			}
 			rest.RenderJSON(w, claims.User)


### PR DESCRIPTION
It happens when `err=nil` and `claims.User=nil` in Handlers() func.

https://github.com/go-pkgz/auth/blob/master/auth.go#L184