### PR TITLE
Fix custom server return URL decoding

### DIFF
--- a/_example/README.md
+++ b/_example/README.md
@@ -3,8 +3,8 @@
 ## build and try
 
 - run `go run main.go`
-- open route: http://127.0.0.1:8080/open
-- web application - http://127.0.0.1:8080/web
+- open route: http://localhost:8080/open
+- web application - http://localhost:8080/web
 
 ## parameters
 

--- a/provider/custom_server.go
+++ b/provider/custom_server.go
@@ -135,7 +135,7 @@ func (c *CustomServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			formData := struct{ Query string }{Query: r.URL.RawQuery}
+			formData := struct{ Query template.URL }{Query: template.URL(r.URL.RawQuery)} //nolint:gosec // query is safe
 
 			if err := userLoginTmpl.Execute(w, formData); err != nil {
 				c.Logf("[WARN] can't write, %s", err)

--- a/provider/dev_provider.go
+++ b/provider/dev_provider.go
@@ -67,7 +67,7 @@ func (d *DevAuthServer) Run(ctx context.Context) { // nolint (gocyclo)
 
 				// first time it will be called without username and will ask for one
 				if !d.Automatic && (r.ParseForm() != nil || r.Form.Get("username") == "") {
-					formData := struct{ Query template.URL }{Query: template.URL(r.URL.RawQuery)} //nolint:gosec // query is safes
+					formData := struct{ Query template.URL }{Query: template.URL(r.URL.RawQuery)} //nolint:gosec // query is safe
 					if err = userFormTmpl.Execute(w, formData); err != nil {
 						d.Logf("[WARN] can't write, %s", err)
 					}


### PR DESCRIPTION
Previously the form escaped the return URL twice, preventing it from working.

Resolves #130.