### PR TITLE
fix: Get request from web to private page

### DIFF
--- a/token/jwt.go
+++ b/token/jwt.go
@@ -299,6 +299,13 @@ func (j *Service) Get(r *http.Request) (Claims, string, error) {
 
 	if fromCookie && claims.User != nil {
 		xsrf := r.Header.Get(j.XSRFHeaderKey)
+		if xsrf == "" {
+			cxsrf, err := r.Cookie(j.XSRFCookieName)
+			if err == nil {
+				xsrf = cxsrf.Value
+			}
+		}
+
 		if claims.Id != xsrf {
 			return Claims{}, "", fmt.Errorf("xsrf mismatch")
 		}


### PR DESCRIPTION
if you have Get request from web to private page, you can't set data in header without JS