### PR TITLE
Fixed that gravatar doesn't updated at login sometimes

### DIFF
--- a/avatar/avatar.go
+++ b/avatar/avatar.go
@@ -211,7 +211,7 @@ func GetGravatarURL(email string) (res string, err error) {
 	hash := md5.Sum([]byte(email))
 	hexHash := hex.EncodeToString(hash[:])
 
-	client := http.Client{Timeout: 1 * time.Second}
+	client := http.Client{Timeout: 5 * time.Second}
 	res = "https://www.gravatar.com/avatar/" + hexHash + ".jpg"
 	resp, err := client.Get(res + "?d=404&s=80")
 	if err != nil {


### PR DESCRIPTION
Avatar image from gravatar must be updated on each user's login. But sometime it doesn't work. After research found a possible problem:
 - Current timeout for gravatar: 1 second. It's too low;
 - Current download times for gravatar images by API: 0.9 - 1.2 second.

PR increases a timeout from 1 to 5 seconds, so that must fix the problem.