### PR TITLE
Add possibility to get additional user data (additional scope)

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -222,6 +222,7 @@ func (s *Service) Middleware() middleware.Authenticator {
 	return s.authMiddleware
 }
 
+// AddProviderWithUserAttributes adds provider with user attributes mapping
 func (s *Service) AddProviderWithUserAttributes(name, cid, csecret string, userAttributes provider.UserAttributes) {
 	p := provider.Params{
 		URL:            s.opts.URL,

--- a/auth.go
+++ b/auth.go
@@ -222,19 +222,21 @@ func (s *Service) Middleware() middleware.Authenticator {
 	return s.authMiddleware
 }
 
-// AddProvider adds provider for given name
-func (s *Service) AddProvider(name, cid, csecret string) {
-
+func (s *Service) AddProviderWithUserAttributes(name, cid, csecret string, userAttributes provider.UserAttributes) {
 	p := provider.Params{
-		URL:         s.opts.URL,
-		JwtService:  s.jwtService,
-		Issuer:      s.issuer,
-		AvatarSaver: s.avatarProxy,
-		Cid:         cid,
-		Csecret:     csecret,
-		L:           s.logger,
+		URL:            s.opts.URL,
+		JwtService:     s.jwtService,
+		Issuer:         s.issuer,
+		AvatarSaver:    s.avatarProxy,
+		Cid:            cid,
+		Csecret:        csecret,
+		L:              s.logger,
+		UserAttributes: userAttributes,
 	}
+	s.addProvider(name, p)
+}
 
+func (s *Service) addProvider(name string, p provider.Params) {
 	switch strings.ToLower(name) {
 	case "github":
 		s.providers = append(s.providers, provider.NewService(provider.NewGithub(p)))
@@ -259,6 +261,23 @@ func (s *Service) AddProvider(name, cid, csecret string) {
 	}
 
 	s.authMiddleware.Providers = s.providers
+}
+
+// AddProvider adds provider for given name
+func (s *Service) AddProvider(name, cid, csecret string) {
+
+	p := provider.Params{
+		URL:            s.opts.URL,
+		JwtService:     s.jwtService,
+		Issuer:         s.issuer,
+		AvatarSaver:    s.avatarProxy,
+		Cid:            cid,
+		Csecret:        csecret,
+		L:              s.logger,
+		UserAttributes: map[string]string{},
+	}
+
+	s.addProvider(name, p)
 }
 
 // AddDevProvider with a custom host and port

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -34,12 +34,13 @@ type Oauth2Handler struct {
 // Params to make initialized and ready to use provider
 type Params struct {
 	logger.L
-	URL         string
-	JwtService  TokenService
-	Cid         string
-	Csecret     string
-	Issuer      string
-	AvatarSaver AvatarSaver
+	URL            string
+	JwtService     TokenService
+	Cid            string
+	Csecret        string
+	Issuer         string
+	AvatarSaver    AvatarSaver
+	UserAttributes UserAttributes
 
 	Port int    // relevant for providers supporting port customization, for example dev oauth2
 	Host string // relevant for providers supporting host customization, for example dev oauth2

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/oauth2/yandex"
 )
 
+type UserAttributes map[string]string
+
 // NewGoogle makes google oauth2 provider
 func NewGoogle(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
@@ -33,6 +35,9 @@ func NewGoogle(p Params) Oauth2Handler {
 			}
 			if userInfo.Name == "" {
 				userInfo.Name = "noname_" + userInfo.ID[8:12]
+			}
+			for k, v := range p.UserAttributes {
+				userInfo.SetStrAttr(v, data.Value(k))
 			}
 			return userInfo
 		},
@@ -55,6 +60,9 @@ func NewGithub(p Params) Oauth2Handler {
 			// github may have no user name, use login in this case
 			if userInfo.Name == "" {
 				userInfo.Name = data.Value("login")
+			}
+			for k, v := range p.UserAttributes {
+				userInfo.SetStrAttr(v, data.Value(k))
 			}
 			return userInfo
 		},
@@ -93,6 +101,9 @@ func NewFacebook(p Params) Oauth2Handler {
 			if err := json.Unmarshal(bdata, &uinfoJSON); err == nil {
 				userInfo.Picture = uinfoJSON.Picture.Data.URL
 			}
+			for k, v := range p.UserAttributes {
+				userInfo.SetStrAttr(v, data.Value(k))
+			}
 			return userInfo
 		},
 	})
@@ -121,6 +132,9 @@ func NewYandex(p Params) Oauth2Handler {
 			if data.Value("default_avatar_id") != "" {
 				userInfo.Picture = fmt.Sprintf("https://avatars.yandex.net/get-yapic/%s/islands-200", data.Value("default_avatar_id"))
 			}
+			for k, v := range p.UserAttributes {
+				userInfo.SetStrAttr(v, data.Value(k))
+			}
 			return userInfo
 		},
 	})
@@ -143,6 +157,9 @@ func NewTwitter(p Params) Oauth1Handler {
 			if userInfo.Name == "" {
 				userInfo.Name = data.Value("name")
 			}
+			for k, v := range p.UserAttributes {
+				userInfo.SetStrAttr(v, data.Value(k))
+			}
 			return userInfo
 		},
 	})
@@ -164,7 +181,9 @@ func NewBattlenet(p Params) Oauth2Handler {
 				ID:   "battlenet_" + token.HashID(sha1.New(), data.Value("id")),
 				Name: data.Value("battletag"),
 			}
-
+			for k, v := range p.UserAttributes {
+				userInfo.SetStrAttr(v, data.Value(k))
+			}
 			return userInfo
 		},
 	})
@@ -184,6 +203,9 @@ func NewMicrosoft(p Params) Oauth2Handler {
 				ID:      "microsoft_" + token.HashID(sha1.New(), data.Value("id")),
 				Name:    data.Value("displayName"),
 				Picture: "https://graph.microsoft.com/beta/me/photo/$value",
+			}
+			for k, v := range p.UserAttributes {
+				userInfo.SetStrAttr(v, data.Value(k))
 			}
 			return userInfo
 		},
@@ -235,7 +257,9 @@ func NewPatreon(p Params) Oauth2Handler {
 					userInfo.SetPaidSub(true)
 				}
 			}
-
+			for k, v := range p.UserAttributes {
+				userInfo.SetStrAttr(v, data.Value(k))
+			}
 			return userInfo
 		},
 	})

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/oauth2/yandex"
 )
 
-//Type that will be used to map user data from provider to token.User
+// UserAttributes is the type that will be used to map user data from provider to token.User
 type UserAttributes map[string]string
 
 // NewGoogle makes google oauth2 provider

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/oauth2/yandex"
 )
 
+//Type that will be used to map user data from provider to token.User
 type UserAttributes map[string]string
 
 // NewGoogle makes google oauth2 provider


### PR DESCRIPTION
Hi, 
I added the possibility to get additional customer information (instead of just username, avatar and id).

Use case:
I use this library in my project and want to simplify user authorization as much as possible. My application is require to have at least email to proceed of using full functionality of application, and I don't see any reason to limit it if customer already provide it in one of the providers and authorize to use this data in application. 

Backward compatibility
The solution is backward compatible. I saw that library still not released and we can legally broke contracts, but to avoid additional work for customers I didn't change API, just add new public method to use. 

All additional fields will go under attributes section. Example: 
```
{
"name":"Volodymyr Zaiets",
"id":"github_368140cb0b52a8d0758818421b75b40aa6d8e25f",
"picture":"http://localhost:8080/avatar/",
"aud":"freehands",
"attrs":{"avatar_url":"https://avatars.githubusercontent.com/u/8035672?v=4","email":"vzaets@adobe.com"}
}
```

