### PR TITLE
Fixed wrong gravatar url generation (lower case, file type)

### DIFF
--- a/avatar/avatar.go
+++ b/avatar/avatar.go
@@ -208,11 +208,11 @@ func GenerateAvatar(user string) ([]byte, error) {
 // GetGravatarURL returns url to gravatar picture for given email
 func GetGravatarURL(email string) (res string, err error) {
 
-	hash := md5.Sum([]byte(email))
+	hash := md5.Sum([]byte(strings.ToLower(strings.TrimSpace(email))))
 	hexHash := hex.EncodeToString(hash[:])
 
 	client := http.Client{Timeout: 1 * time.Second}
-	res = "https://www.gravatar.com/avatar/" + hexHash + ".jpg"
+	res = "https://www.gravatar.com/avatar/" + hexHash
 	resp, err := client.Get(res + "?d=404&s=80")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixed two bugs:
1. According to [gravatar docs](https://en.gravatar.com/site/implement/images/) must be used trimmed and lower case email for url generation;
2. File-type extension doesn't work nowadays, so must use default file format (png).

File-type extension examples:
* good url (without file ext): https://www.gravatar.com/avatar/a443dd413b286902c47da02fe0a56e5e?d=404&s=80
* broken url (with file ext): https://www.gravatar.com/avatar/a443dd413b286902c47da02fe0a56e5e.jpg?d=404&s=80