### PR TITLE
Fix registration of dev provider in Service.authMiddleware.Providers

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -234,39 +234,44 @@ func (s *Service) AddProviderWithUserAttributes(name, cid, csecret string, userA
 		L:              s.logger,
 		UserAttributes: userAttributes,
 	}
-	s.addProvider(name, p)
+	s.addProviderByName(name, p)
 }
 
-func (s *Service) addProvider(name string, p provider.Params) {
+func (s *Service) addProviderByName(name string, p provider.Params) {
+	var prov provider.Provider
 	switch strings.ToLower(name) {
 	case "github":
-		s.providers = append(s.providers, provider.NewService(provider.NewGithub(p)))
+		prov = provider.NewGithub(p)
 	case "google":
-		s.providers = append(s.providers, provider.NewService(provider.NewGoogle(p)))
+		prov = provider.NewGoogle(p)
 	case "facebook":
-		s.providers = append(s.providers, provider.NewService(provider.NewFacebook(p)))
+		prov = provider.NewFacebook(p)
 	case "yandex":
-		s.providers = append(s.providers, provider.NewService(provider.NewYandex(p)))
+		prov = provider.NewYandex(p)
 	case "battlenet":
-		s.providers = append(s.providers, provider.NewService(provider.NewBattlenet(p)))
+		prov = provider.NewBattlenet(p)
 	case "microsoft":
-		s.providers = append(s.providers, provider.NewService(provider.NewMicrosoft(p)))
+		prov = provider.NewMicrosoft(p)
 	case "twitter":
-		s.providers = append(s.providers, provider.NewService(provider.NewTwitter(p)))
+		prov = provider.NewTwitter(p)
 	case "patreon":
-		s.providers = append(s.providers, provider.NewService(provider.NewPatreon(p)))
+		prov = provider.NewPatreon(p)
 	case "dev":
-		s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))
+		prov = provider.NewDev(p)
 	default:
 		return
 	}
 
+	s.addProvider(prov)
+}
+
+func (s *Service) addProvider(prov provider.Provider) {
+	s.providers = append(s.providers, provider.NewService(prov))
 	s.authMiddleware.Providers = s.providers
 }
 
 // AddProvider adds provider for given name
 func (s *Service) AddProvider(name, cid, csecret string) {
-
 	p := provider.Params{
 		URL:            s.opts.URL,
 		JwtService:     s.jwtService,
@@ -277,8 +282,7 @@ func (s *Service) AddProvider(name, cid, csecret string) {
 		L:              s.logger,
 		UserAttributes: map[string]string{},
 	}
-
-	s.addProvider(name, p)
+	s.addProviderByName(name, p)
 }
 
 // AddDevProvider with a custom host and port
@@ -292,7 +296,7 @@ func (s *Service) AddDevProvider(host string, port int) {
 		Port:        port,
 		Host:        host,
 	}
-	s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))
+	s.addProvider(provider.NewDev(p))
 }
 
 // AddAppleProvider allow SignIn with Apple ID
@@ -311,7 +315,7 @@ func (s *Service) AddAppleProvider(appleConfig provider.AppleConfig, privKeyLoad
 		return fmt.Errorf("an AppleProvider creating failed: %w", err)
 	}
 
-	s.providers = append(s.providers, provider.NewService(appleProvider))
+	s.addProvider(appleProvider)
 	return nil
 }
 
@@ -326,9 +330,7 @@ func (s *Service) AddCustomProvider(name string, client Client, copts provider.C
 		Csecret:     client.Csecret,
 		L:           s.logger,
 	}
-
-	s.providers = append(s.providers, provider.NewService(provider.NewCustom(name, p, copts)))
-	s.authMiddleware.Providers = s.providers
+	s.addProvider(provider.NewCustom(name, p, copts))
 }
 
 // AddDirectProvider adds provider with direct check against data store
@@ -342,8 +344,7 @@ func (s *Service) AddDirectProvider(name string, credChecker provider.CredChecke
 		CredChecker:  credChecker,
 		AvatarSaver:  s.avatarProxy,
 	}
-	s.providers = append(s.providers, provider.NewService(dh))
-	s.authMiddleware.Providers = s.providers
+	s.addProvider(dh)
 }
 
 // AddDirectProviderWithUserIDFunc adds provider with direct check against data store and sets custom UserIDFunc allows
@@ -359,8 +360,7 @@ func (s *Service) AddDirectProviderWithUserIDFunc(name string, credChecker provi
 		AvatarSaver:  s.avatarProxy,
 		UserIDFunc:   ufn,
 	}
-	s.providers = append(s.providers, provider.NewService(dh))
-	s.authMiddleware.Providers = s.providers
+	s.addProvider(dh)
 }
 
 // AddVerifProvider adds provider user's verification sent by sender
@@ -375,14 +375,12 @@ func (s *Service) AddVerifProvider(name, msgTmpl string, sender provider.Sender)
 		Template:     msgTmpl,
 		UseGravatar:  s.useGravatar,
 	}
-	s.providers = append(s.providers, provider.NewService(dh))
-	s.authMiddleware.Providers = s.providers
+	s.addProvider(dh)
 }
 
 // AddCustomHandler adds user-defined self-implemented handler of auth provider
-func (s *Service) AddCustomHandler(handler provider.Provider) {
-	s.providers = append(s.providers, provider.NewService(handler))
-	s.authMiddleware.Providers = s.providers
+func (s *Service) AddCustomHandler(p provider.Provider) {
+	s.addProvider(p)
 }
 
 // DevAuth makes dev oauth2 server, for testing and development only!

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -234,39 +234,44 @@ func (s *Service) AddProviderWithUserAttributes(name, cid, csecret string, userA
 		L:              s.logger,
 		UserAttributes: userAttributes,
 	}
-	s.addProvider(name, p)
+	s.addProviderByName(name, p)
 }
 
-func (s *Service) addProvider(name string, p provider.Params) {
+func (s *Service) addProviderByName(name string, p provider.Params) {
+	var prov provider.Provider
 	switch strings.ToLower(name) {
 	case "github":
-		s.providers = append(s.providers, provider.NewService(provider.NewGithub(p)))
+		prov = provider.NewGithub(p)
 	case "google":
-		s.providers = append(s.providers, provider.NewService(provider.NewGoogle(p)))
+		prov = provider.NewGoogle(p)
 	case "facebook":
-		s.providers = append(s.providers, provider.NewService(provider.NewFacebook(p)))
+		prov = provider.NewFacebook(p)
 	case "yandex":
-		s.providers = append(s.providers, provider.NewService(provider.NewYandex(p)))
+		prov = provider.NewYandex(p)
 	case "battlenet":
-		s.providers = append(s.providers, provider.NewService(provider.NewBattlenet(p)))
+		prov = provider.NewBattlenet(p)
 	case "microsoft":
-		s.providers = append(s.providers, provider.NewService(provider.NewMicrosoft(p)))
+		prov = provider.NewMicrosoft(p)
 	case "twitter":
-		s.providers = append(s.providers, provider.NewService(provider.NewTwitter(p)))
+		prov = provider.NewTwitter(p)
 	case "patreon":
-		s.providers = append(s.providers, provider.NewService(provider.NewPatreon(p)))
+		prov = provider.NewPatreon(p)
 	case "dev":
-		s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))
+		prov = provider.NewDev(p)
 	default:
 		return
 	}
 
+	s.addProvider(prov)
+}
+
+func (s *Service) addProvider(prov provider.Provider) {
+	s.providers = append(s.providers, provider.NewService(prov))
 	s.authMiddleware.Providers = s.providers
 }
 
 // AddProvider adds provider for given name
 func (s *Service) AddProvider(name, cid, csecret string) {
-
 	p := provider.Params{
 		URL:            s.opts.URL,
 		JwtService:     s.jwtService,
@@ -277,8 +282,7 @@ func (s *Service) AddProvider(name, cid, csecret string) {
 		L:              s.logger,
 		UserAttributes: map[string]string{},
 	}
-
-	s.addProvider(name, p)
+	s.addProviderByName(name, p)
 }
 
 // AddDevProvider with a custom host and port
@@ -292,7 +296,7 @@ func (s *Service) AddDevProvider(host string, port int) {
 		Port:        port,
 		Host:        host,
 	}
-	s.providers = append(s.providers, provider.NewService(provider.NewDev(p)))
+	s.addProvider(provider.NewDev(p))
 }
 
 // AddAppleProvider allow SignIn with Apple ID
@@ -311,7 +315,7 @@ func (s *Service) AddAppleProvider(appleConfig provider.AppleConfig, privKeyLoad
 		return fmt.Errorf("an AppleProvider creating failed: %w", err)
 	}
 
-	s.providers = append(s.providers, provider.NewService(appleProvider))
+	s.addProvider(appleProvider)
 	return nil
 }
 
@@ -326,9 +330,7 @@ func (s *Service) AddCustomProvider(name string, client Client, copts provider.C
 		Csecret:     client.Csecret,
 		L:           s.logger,
 	}
-
-	s.providers = append(s.providers, provider.NewService(provider.NewCustom(name, p, copts)))
-	s.authMiddleware.Providers = s.providers
+	s.addProvider(provider.NewCustom(name, p, copts))
 }
 
 // AddDirectProvider adds provider with direct check against data store
@@ -342,8 +344,7 @@ func (s *Service) AddDirectProvider(name string, credChecker provider.CredChecke
 		CredChecker:  credChecker,
 		AvatarSaver:  s.avatarProxy,
 	}
-	s.providers = append(s.providers, provider.NewService(dh))
-	s.authMiddleware.Providers = s.providers
+	s.addProvider(dh)
 }
 
 // AddDirectProviderWithUserIDFunc adds provider with direct check against data store and sets custom UserIDFunc allows
@@ -359,8 +360,7 @@ func (s *Service) AddDirectProviderWithUserIDFunc(name string, credChecker provi
 		AvatarSaver:  s.avatarProxy,
 		UserIDFunc:   ufn,
 	}
-	s.providers = append(s.providers, provider.NewService(dh))
-	s.authMiddleware.Providers = s.providers
+	s.addProvider(dh)
 }
 
 // AddVerifProvider adds provider user's verification sent by sender
@@ -375,14 +375,12 @@ func (s *Service) AddVerifProvider(name, msgTmpl string, sender provider.Sender)
 		Template:     msgTmpl,
 		UseGravatar:  s.useGravatar,
 	}
-	s.providers = append(s.providers, provider.NewService(dh))
-	s.authMiddleware.Providers = s.providers
+	s.addProvider(dh)
 }
 
 // AddCustomHandler adds user-defined self-implemented handler of auth provider
-func (s *Service) AddCustomHandler(handler provider.Provider) {
-	s.providers = append(s.providers, provider.NewService(handler))
-	s.authMiddleware.Providers = s.providers
+func (s *Service) AddCustomHandler(p provider.Provider) {
+	s.addProvider(p)
 }
 
 // DevAuth makes dev oauth2 server, for testing and development only!

--- a/v2/auth_test.go
+++ b/v2/auth_test.go
@@ -52,12 +52,13 @@ func TestProvider(t *testing.T) {
 	_, err := svc.Provider("some provider")
 	assert.EqualError(t, err, "provider some provider not found")
 
-	svc.AddProvider("dev", "cid", "csecret")
+	svc.AddProviderWithUserAttributes("dev", "cid", "csecret", provider.UserAttributes{"attrName": "attrValue"})
 	svc.AddProvider("github", "cid", "csecret")
 	svc.AddProvider("google", "cid", "csecret")
 	svc.AddProvider("facebook", "cid", "csecret")
 	svc.AddProvider("yandex", "cid", "csecret")
 	svc.AddProvider("microsoft", "cid", "csecret")
+	svc.AddProvider("twitter", "cid", "csecret")
 	svc.AddProvider("battlenet", "cid", "csecret")
 	svc.AddProvider("patreon", "cid", "csecret")
 	svc.AddProvider("bad", "cid", "csecret")
@@ -72,6 +73,7 @@ func TestProvider(t *testing.T) {
 	assert.Equal(t, "cid", op.Cid)
 	assert.Equal(t, "csecret", op.Csecret)
 	assert.Equal(t, "go-pkgz/auth", op.Issuer)
+	assert.Equal(t, provider.UserAttributes{"attrName": "attrValue"}, op.Params.UserAttributes)
 
 	p, err = svc.Provider("github")
 	assert.NoError(t, err)
@@ -79,7 +81,7 @@ func TestProvider(t *testing.T) {
 	assert.Equal(t, "github", op.Name())
 
 	pp := svc.Providers()
-	assert.Equal(t, 9, len(pp))
+	assert.Equal(t, 10, len(pp))
 
 	ch, err := svc.Provider("telegramBotMySiteCom")
 	assert.NoError(t, err)
@@ -505,6 +507,15 @@ func TestStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "{\"status\":\"logged in\",\"user\":\"dev_user\"}\n", string(b))
 
+}
+
+func TestDevAuthServerWithoutDevProvider(t *testing.T) {
+	svc := NewService(Opts{})
+	assert.NotNil(t, svc)
+
+	_, err := svc.DevAuth()
+	require.NotNil(t, err)
+	assert.EqualError(t, err, "dev provider not registered: provider dev not found")
 }
 
 func prepService(t *testing.T, providerConfigFunctions ...func(svc *Service)) (svc *Service, teardown func()) { //nolint unparam


### PR DESCRIPTION
There was one minor problem related to the dev and Apple providers registration.

Now it is possible to have a configuration,
where only one single dev provider is enabled.

Providers were not registered into `Service.authMiddleware.Providers` slice in the `Service.AddDevProvider()` and `Service.AddAppleProvider()` methods before.

This worked before, because other providers were registered at the same time, and `authMiddleware.Providers` slice was reassigned by other methods.