### PR TITLE
Set proper "content-type" while calling JwtService.Reset()

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -292,6 +292,7 @@ func TestLogout(t *testing.T) {
 	resp, err = client.Get("http://127.0.0.1:8089/auth/logout")
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	defer resp.Body.Close()
 
 	resp, err = client.Get("http://127.0.0.1:8089/private")

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -321,6 +321,8 @@ func (j *Service) Reset(w http.ResponseWriter) {
 	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain,
 		MaxAge: -1, Expires: time.Unix(0, 0), Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &xsrfCookie)
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 }
 
 // checkAuds verifies if claims.Audience in the list of allowed by audReader

--- a/v2/auth_test.go
+++ b/v2/auth_test.go
@@ -292,6 +292,7 @@ func TestLogout(t *testing.T) {
 	resp, err = client.Get("http://127.0.0.1:8089/auth/logout")
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	defer resp.Body.Close()
 
 	resp, err = client.Get("http://127.0.0.1:8089/private")

--- a/v2/token/jwt.go
+++ b/v2/token/jwt.go
@@ -321,6 +321,8 @@ func (j *Service) Reset(w http.ResponseWriter) {
 	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain,
 		MaxAge: -1, Expires: time.Unix(0, 0), Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &xsrfCookie)
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 }
 
 // checkAuds verifies if claims.Audience in the list of allowed by audReader


### PR DESCRIPTION
During "LogOut", JwtService.Reset() doesn't set "content-type" header that leads to "XML Parsing Error: no root element found" in FireFox.
This PR simply adds proper header.