### PR TITLE
Implement XSRFIgnoreMethods

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,21 @@ For more details refer to [Complete Guide of Battle.net OAuth API and Login Butt
 1.	Fill **App name**  and **Description** and **URL** of your site
 1.	In the field **Callback URLs** enter the correct url of your callback handler e.g. https://example.mysite.com/{route}/twitter/callback
 1.	Under **Key and tokens** take note of the **Consumer API Key** and **Consumer API Secret key**. Those will be used as `cid` and `csecret`
+
+## XSRF Protections
+By default, the XSRF protections will apply to all requests which reach the `middlewares.Auth`,
+`middlewares.Admin` or `middlewares.RBAC` middlewares. This will require setting a request header 
+with a key of `<XSRFHeaderKey>` containing the value of the cookie named `<XSRFCookieName>`.
+
+To disable all XSRF protections, set `DisableXSRF` to `true`. This should probably only be used 
+during testing or debugging.
+
+When setting a custom request header is not possible, such as when building a web application which
+is not a Single-Page-Application and HTML link tags are used to navigate pages, specific HTTP methods
+may be excluded using the `XSRFIgnoreMethods` option. For example, to disable GET requests, set this
+option to `XSRFIgnoreMethods: []string{"GET"}`. Adding methods other than GET to this list may result
+in XSRF vulnerabilities.
+
 ## Status
 
 The library extracted from [remark42](https://github.com/umputun/remark) project. The original code in production use on multiple sites and seems to work fine.

--- a/auth.go
+++ b/auth.go
@@ -46,14 +46,15 @@ type Opts struct {
 	DisableIAT  bool // disable IssuedAt claim
 
 	// optional (custom) names for cookies and headers
-	JWTCookieName   string        // default "JWT"
-	JWTCookieDomain string        // default empty
-	JWTHeaderKey    string        // default "X-JWT"
-	XSRFCookieName  string        // default "XSRF-TOKEN"
-	XSRFHeaderKey   string        // default "X-XSRF-TOKEN"
-	JWTQuery        string        // default "token"
-	SendJWTHeader   bool          // if enabled send JWT as a header instead of cookie
-	SameSiteCookie  http.SameSite // limit cross-origin requests with SameSite cookie attribute
+	JWTCookieName     string        // default "JWT"
+	JWTCookieDomain   string        // default empty
+	JWTHeaderKey      string        // default "X-JWT"
+	XSRFCookieName    string        // default "XSRF-TOKEN"
+	XSRFHeaderKey     string        // default "X-XSRF-TOKEN"
+	XSRFIgnoreMethods string        // disable XSRF protection for the specified request methods (ex. "GET,POST"), default empty
+	JWTQuery          string        // default "token"
+	SendJWTHeader     bool          // if enabled send JWT as a header instead of cookie
+	SameSiteCookie    http.SameSite // limit cross-origin requests with SameSite cookie attribute
 
 	Issuer string // optional value for iss claim, usually the application name, default "go-pkgz/auth"
 

--- a/auth.go
+++ b/auth.go
@@ -51,7 +51,7 @@ type Opts struct {
 	JWTHeaderKey      string        // default "X-JWT"
 	XSRFCookieName    string        // default "XSRF-TOKEN"
 	XSRFHeaderKey     string        // default "X-XSRF-TOKEN"
-	XSRFIgnoreMethods string        // disable XSRF protection for the specified request methods (ex. "GET,POST"), default empty
+	XSRFIgnoreMethods []string      // disable XSRF protection for the specified request methods (ex. []string{"GET", "POST")}, default empty
 	JWTQuery          string        // default "token"
 	SendJWTHeader     bool          // if enabled send JWT as a header instead of cookie
 	SameSiteCookie    http.SameSite // limit cross-origin requests with SameSite cookie attribute

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -303,7 +303,7 @@ func (j *Service) Get(r *http.Request) (Claims, string, error) {
 		return Claims{}, "", fmt.Errorf("token expired")
 	}
 
-	if j.DisableXSRF || slices.Contains[[]string, string](j.XSRFIgnoreMethods, r.Method) {
+	if j.DisableXSRF || slices.Contains(j.XSRFIgnoreMethods, r.Method) {
 		return claims, tokenString, nil
 	}
 

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -500,7 +500,7 @@ func TestJWT_GetWithXsrfMismatchOnIgnoredMethod(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
-	j.XSRFIgnoreMethods = "GET"
+	j.XSRFIgnoreMethods = []string{"GET"}
 	req := httptest.NewRequest("GET", "/valid", nil)
 	req.AddCookie(resp.Cookies()[0])
 	req.Header.Add(xsrfCustomHeaderKey, "random id wrong")
@@ -508,7 +508,7 @@ func TestJWT_GetWithXsrfMismatchOnIgnoredMethod(t *testing.T) {
 	require.NoError(t, err, "xsrf mismatch, but ignored")
 
 	j.DisableXSRF = true
-	j.XSRFIgnoreMethods = ""
+	j.XSRFIgnoreMethods = []string{}
 	req = httptest.NewRequest("GET", "/valid", nil)
 	req.AddCookie(resp.Cookies()[0])
 	req.Header.Add(xsrfCustomHeaderKey, "random id wrong")


### PR DESCRIPTION
# XSRFIgnoreMethods

## Background
I discovered while using this library that the current XSRF protections do not allow for a GET request sent by the browser on protected routes, due to requiring the presence of the XSRF token in a header. This is a problem for applications that are not SPAs and send GET requests to the server to retrieve a new HTML page. In these situations, the common pattern is to skip XSRF checks on GET requests.

## Solution
To resolve this, I implemented a configuration option called `XSRFIgnoreMethods`, allowing the user to specify a comma-separated list of HTTP methods for which XSRF checks should be skipped when extracting and validating the JWT. I am open to any feedback, modifications, or  discussions about this. 