### PR TITLE
Improve provider name handling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters-settings:
       - rangeValCopy
 
 linters:
-  disable-all: true
   enable:
     - copyloopvar
     - gochecknoinits
@@ -37,41 +36,25 @@ linters:
     - unconvert
     - unused
 
-  fast: false
-
-
 issues:
-  exclude-dirs:
-    - vendor
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude:
+    - "should have a package comment, unless it's in another file for this package"
+    - "exitAfterDefer:"
+    - "whyNoLint: include an explanation for nolint directive"
+    - "go.mongodb.org/mongo-driver/bson/primitive.E"
+    - "weak cryptographic primitive"
+    - "at least one file in a package should have a package comment"
+    - "should have a package comment"
+    - 'Deferring unsafe method "Close" on type "io.ReadCloser"'
   exclude-rules:
-    - text: "should have a package comment, unless it's in another file for this package"
-      linters:
-        - golint
-    - text: "exitAfterDefer:"
-      linters:
-        - gocritic
-    - text: "whyNoLint: include an explanation for nolint directive"
-      linters:
-        - gocritic
-    - text: "go.mongodb.org/mongo-driver/bson/primitive.E"
-      linters:
-        - govet
-    - text: "weak cryptographic primitive"
-      linters:
-        - gosec
-    - text: "at least one file in a package should have a package comment"
-      linters:
-        - stylecheck
-    - text: "should have a package comment"
-      linters:
-        - revive
-    - text: 'Deferring unsafe method "Close" on type "io.ReadCloser"'
-      linters:
-        - gosec
     - linters:
         - unparam
         - unused
         - revive
       path: _test\.go$
       text: "unused-parameter"
-  exclude-use-default: false
+    - linters:
+        - errcheck
+      path: _test\.go$

--- a/auth.go
+++ b/auth.go
@@ -4,6 +4,8 @@ package auth
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -270,8 +272,40 @@ func (s *Service) addProviderByName(name string, p provider.Params) {
 }
 
 func (s *Service) addProvider(prov provider.Provider) {
+	if !s.isValidProviderName(prov.Name()) {
+		return
+	}
 	s.providers = append(s.providers, provider.NewService(prov))
 	s.authMiddleware.Providers = s.providers
+}
+
+func (s *Service) isValidProviderName(name string) bool {
+	if strings.TrimSpace(name) == "" {
+		s.logger.Logf("[ERROR] provider has been ignored because its name is empty")
+		return false
+	}
+
+	formatForbidden := func(name string) {
+		s.logger.Logf("[ERROR] provider has been ignored because its name contains forbidden characters: '%s'", name)
+	}
+
+	path, err := url.PathUnescape(name)
+	if err != nil || path != name {
+		formatForbidden(name)
+		return false
+	}
+	if name != url.PathEscape(name) {
+		formatForbidden(name)
+		return false
+	}
+	// net/url package does not escape everything (https://github.com/golang/go/issues/5684)
+	// It is better to reject all reserved characters from https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
+	if regexp.MustCompile(`[:/?#\[\]@!$&'\(\)*+,;=]`).MatchString(name) {
+		formatForbidden(name)
+		return false
+	}
+
+	return true
 }
 
 // AddProvider adds provider for given name

--- a/auth.go
+++ b/auth.go
@@ -285,23 +285,23 @@ func (s *Service) isValidProviderName(name string) bool {
 		return false
 	}
 
-	formatForbidden := func(name string) {
-		s.logger.Logf("[ERROR] provider has been ignored because its name contains forbidden characters: '%s'", name)
+	formatForbidden := func(name string) string {
+		return fmt.Sprintf("provider has been ignored because its name contains forbidden characters: '%s'", name)
 	}
 
 	path, err := url.PathUnescape(name)
 	if err != nil || path != name {
-		formatForbidden(name)
+		s.logger.Logf("[ERROR] %s", formatForbidden(name))
 		return false
 	}
 	if name != url.PathEscape(name) {
-		formatForbidden(name)
+		s.logger.Logf("[ERROR] %s", formatForbidden(name))
 		return false
 	}
 	// net/url package does not escape everything (https://github.com/golang/go/issues/5684)
 	// It is better to reject all reserved characters from https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
 	if regexp.MustCompile(`[:/?#\[\]@!$&'\(\)*+,;=]`).MatchString(name) {
-		formatForbidden(name)
+		s.logger.Logf("[ERROR] %s", formatForbidden(name))
 		return false
 	}
 

--- a/provider/apple.go
+++ b/provider/apple.go
@@ -267,6 +267,9 @@ func (ah *AppleHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			ExpiresAt: time.Now().Add(30 * time.Minute).Unix(),
 			NotBefore: time.Now().Add(-1 * time.Minute).Unix(),
 		},
+		AuthProvider: &token.AuthProvider{
+			Name: ah.name,
+		},
 	}
 
 	if _, err = ah.JwtService.Set(w, claims); err != nil {
@@ -376,6 +379,9 @@ func (ah AppleHandler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 			Audience: oauthClaims.Audience,
 		},
 		SessionOnly: false,
+		AuthProvider: &token.AuthProvider{
+			Name: ah.name,
+		},
 	}
 
 	if _, err = ah.JwtService.Set(w, claims); err != nil {

--- a/provider/direct.go
+++ b/provider/direct.go
@@ -126,6 +126,9 @@ func (p DirectHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			Audience: creds.Audience,
 		},
 		SessionOnly: sessOnly,
+		AuthProvider: &token.AuthProvider{
+			Name: p.ProviderName,
+		},
 	}
 
 	if _, err = p.TokenService.Set(w, claims); err != nil {

--- a/provider/oauth1.go
+++ b/provider/oauth1.go
@@ -61,6 +61,9 @@ func (h Oauth1Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			ExpiresAt: time.Now().Add(30 * time.Minute).Unix(),
 			NotBefore: time.Now().Add(-1 * time.Minute).Unix(),
 		},
+		AuthProvider: &token.AuthProvider{
+			Name: h.name,
+		},
 	}
 
 	if _, err = h.JwtService.Set(w, claims); err != nil {
@@ -146,6 +149,9 @@ func (h Oauth1Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 			Audience: oauthClaims.Audience,
 		},
 		SessionOnly: oauthClaims.SessionOnly,
+		AuthProvider: &token.AuthProvider{
+			Name: h.name,
+		},
 	}
 
 	if _, err = h.JwtService.Set(w, claims); err != nil {

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -118,6 +118,9 @@ func (p Oauth2Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			NotBefore: time.Now().Add(-1 * time.Minute).Unix(),
 		},
 		NoAva: r.URL.Query().Get("noava") == "1",
+		AuthProvider: &token.AuthProvider{
+			Name: p.name,
+		},
 	}
 
 	if _, err := p.JwtService.Set(w, claims); err != nil {
@@ -215,6 +218,9 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		},
 		SessionOnly: oauthClaims.SessionOnly,
 		NoAva:       oauthClaims.NoAva,
+		AuthProvider: &token.AuthProvider{
+			Name: p.name,
+		},
 	}
 
 	if _, err = p.JwtService.Set(w, claims); err != nil {

--- a/provider/telegram.go
+++ b/provider/telegram.go
@@ -311,7 +311,7 @@ func (th *TelegramHandler) LoginHandler(w http.ResponseWriter, r *http.Request) 
 		},
 		SessionOnly: false, // TODO review?
 		AuthProvider: &authtoken.AuthProvider{
-			Name: th.Name(),
+			Name: th.ProviderName,
 		},
 	}
 

--- a/provider/telegram.go
+++ b/provider/telegram.go
@@ -310,6 +310,9 @@ func (th *TelegramHandler) LoginHandler(w http.ResponseWriter, r *http.Request) 
 			NotBefore: time.Now().Add(-1 * time.Minute).Unix(),
 		},
 		SessionOnly: false, // TODO review?
+		AuthProvider: &authtoken.AuthProvider{
+			Name: th.Name(),
+		},
 	}
 
 	if _, err := th.TokenService.Set(w, claims); err != nil {

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -117,6 +117,9 @@ func (e VerifyHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			Audience: confClaims.Audience,
 		},
 		SessionOnly: sessOnly,
+		AuthProvider: &token.AuthProvider{
+			Name: e.ProviderName,
+		},
 	}
 
 	if _, err = e.TokenService.Set(w, claims); err != nil {
@@ -151,6 +154,9 @@ func (e VerifyHandler) sendConfirmation(w http.ResponseWriter, r *http.Request) 
 			ExpiresAt: time.Now().Add(30 * time.Minute).Unix(),
 			NotBefore: time.Now().Add(-1 * time.Minute).Unix(),
 			Issuer:    e.Issuer,
+		},
+		AuthProvider: &token.AuthProvider{
+			Name: e.ProviderName,
 		},
 	}
 

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -21,10 +21,11 @@ type Service struct {
 // Claims stores user info for token and state & from from login
 type Claims struct {
 	jwt.StandardClaims
-	User        *User      `json:"user,omitempty"` // user info
-	SessionOnly bool       `json:"sess_only,omitempty"`
-	Handshake   *Handshake `json:"handshake,omitempty"` // used for oauth handshake
-	NoAva       bool       `json:"no-ava,omitempty"`    // disable avatar, always use identicon
+	User         *User         `json:"user,omitempty"` // user info
+	SessionOnly  bool          `json:"sess_only,omitempty"`
+	Handshake    *Handshake    `json:"handshake,omitempty"`     // used for oauth handshake
+	NoAva        bool          `json:"no-ava,omitempty"`        // disable avatar, always use identicon
+	AuthProvider *AuthProvider `json:"auth_provider,omitempty"` // auth provider info
 }
 
 // Handshake used for oauth handshake
@@ -32,6 +33,11 @@ type Handshake struct {
 	State string `json:"state,omitempty"`
 	From  string `json:"from,omitempty"`
 	ID    string `json:"id,omitempty"`
+}
+
+// AuthProvider stores attributes of provider which has created a JWT token
+type AuthProvider struct {
+	Name string `json:"name,omitempty"`
 }
 
 const (

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -4,6 +4,8 @@ package auth
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -270,8 +272,40 @@ func (s *Service) addProviderByName(name string, p provider.Params) {
 }
 
 func (s *Service) addProvider(prov provider.Provider) {
+	if !s.isValidProviderName(prov.Name()) {
+		return
+	}
 	s.providers = append(s.providers, provider.NewService(prov))
 	s.authMiddleware.Providers = s.providers
+}
+
+func (s *Service) isValidProviderName(name string) bool {
+	if strings.TrimSpace(name) == "" {
+		s.logger.Logf("[ERROR] provider has been ignored because its name is empty")
+		return false
+	}
+
+	formatForbidden := func(name string) {
+		s.logger.Logf("[ERROR] provider has been ignored because its name contains forbidden characters: '%s'", name)
+	}
+
+	path, err := url.PathUnescape(name)
+	if err != nil || path != name {
+		formatForbidden(name)
+		return false
+	}
+	if name != url.PathEscape(name) {
+		formatForbidden(name)
+		return false
+	}
+	// net/url package does not escape everything (https://github.com/golang/go/issues/5684)
+	// It is better to reject all reserved characters from https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
+	if regexp.MustCompile(`[:/?#\[\]@!$&'\(\)*+,;=]`).MatchString(name) {
+		formatForbidden(name)
+		return false
+	}
+
+	return true
 }
 
 // AddProvider adds provider for given name

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -285,23 +285,23 @@ func (s *Service) isValidProviderName(name string) bool {
 		return false
 	}
 
-	formatForbidden := func(name string) {
-		s.logger.Logf("[ERROR] provider has been ignored because its name contains forbidden characters: '%s'", name)
+	formatForbidden := func(name string) string {
+		return fmt.Sprintf("provider has been ignored because its name contains forbidden characters: '%s'", name)
 	}
 
 	path, err := url.PathUnescape(name)
 	if err != nil || path != name {
-		formatForbidden(name)
+		s.logger.Logf("[ERROR] %s", formatForbidden(name))
 		return false
 	}
 	if name != url.PathEscape(name) {
-		formatForbidden(name)
+		s.logger.Logf("[ERROR] %s", formatForbidden(name))
 		return false
 	}
 	// net/url package does not escape everything (https://github.com/golang/go/issues/5684)
 	// It is better to reject all reserved characters from https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
 	if regexp.MustCompile(`[:/?#\[\]@!$&'\(\)*+,;=]`).MatchString(name) {
-		formatForbidden(name)
+		s.logger.Logf("[ERROR] %s", formatForbidden(name))
 		return false
 	}
 

--- a/v2/provider/apple.go
+++ b/v2/provider/apple.go
@@ -267,6 +267,9 @@ func (ah *AppleHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(30 * time.Minute)),
 			NotBefore: jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
 		},
+		AuthProvider: &token.AuthProvider{
+			Name: ah.name,
+		},
 	}
 
 	if _, err = ah.JwtService.Set(w, claims); err != nil {
@@ -376,6 +379,9 @@ func (ah AppleHandler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 			Audience: oauthClaims.Audience,
 		},
 		SessionOnly: false,
+		AuthProvider: &token.AuthProvider{
+			Name: ah.name,
+		},
 	}
 
 	if _, err = ah.JwtService.Set(w, claims); err != nil {

--- a/v2/provider/direct.go
+++ b/v2/provider/direct.go
@@ -126,6 +126,9 @@ func (p DirectHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			Audience: []string{creds.Audience},
 		},
 		SessionOnly: sessOnly,
+		AuthProvider: &token.AuthProvider{
+			Name: p.ProviderName,
+		},
 	}
 
 	if _, err = p.TokenService.Set(w, claims); err != nil {

--- a/v2/provider/oauth1.go
+++ b/v2/provider/oauth1.go
@@ -61,6 +61,9 @@ func (h Oauth1Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(30 * time.Minute)),
 			NotBefore: jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
 		},
+		AuthProvider: &token.AuthProvider{
+			Name: h.name,
+		},
 	}
 
 	if _, err = h.JwtService.Set(w, claims); err != nil {
@@ -146,6 +149,9 @@ func (h Oauth1Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 			Audience: oauthClaims.Audience,
 		},
 		SessionOnly: oauthClaims.SessionOnly,
+		AuthProvider: &token.AuthProvider{
+			Name: h.name,
+		},
 	}
 
 	if _, err = h.JwtService.Set(w, claims); err != nil {

--- a/v2/provider/oauth2.go
+++ b/v2/provider/oauth2.go
@@ -118,6 +118,9 @@ func (p Oauth2Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			NotBefore: jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
 		},
 		NoAva: r.URL.Query().Get("noava") == "1",
+		AuthProvider: &token.AuthProvider{
+			Name: p.name,
+		},
 	}
 
 	if _, err := p.JwtService.Set(w, claims); err != nil {
@@ -215,6 +218,9 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		},
 		SessionOnly: oauthClaims.SessionOnly,
 		NoAva:       oauthClaims.NoAva,
+		AuthProvider: &token.AuthProvider{
+			Name: p.name,
+		},
 	}
 
 	if _, err = p.JwtService.Set(w, claims); err != nil {

--- a/v2/provider/telegram.go
+++ b/v2/provider/telegram.go
@@ -310,6 +310,9 @@ func (th *TelegramHandler) LoginHandler(w http.ResponseWriter, r *http.Request) 
 			NotBefore: jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
 		},
 		SessionOnly: false, // TODO review?
+		AuthProvider: &authtoken.AuthProvider{
+			Name: th.ProviderName,
+		},
 	}
 
 	if _, err := th.TokenService.Set(w, claims); err != nil {

--- a/v2/provider/verify.go
+++ b/v2/provider/verify.go
@@ -117,6 +117,9 @@ func (e VerifyHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			Audience: confClaims.Audience,
 		},
 		SessionOnly: sessOnly,
+		AuthProvider: &token.AuthProvider{
+			Name: e.ProviderName,
+		},
 	}
 
 	if _, err = e.TokenService.Set(w, claims); err != nil {
@@ -151,6 +154,9 @@ func (e VerifyHandler) sendConfirmation(w http.ResponseWriter, r *http.Request) 
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(30 * time.Minute)),
 			NotBefore: jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
 			Issuer:    e.Issuer,
+		},
+		AuthProvider: &token.AuthProvider{
+			Name: e.ProviderName,
 		},
 	}
 

--- a/v2/token/jwt.go
+++ b/v2/token/jwt.go
@@ -23,10 +23,11 @@ type Service struct {
 // Claims stores user info for token and state & from from login
 type Claims struct {
 	jwt.RegisteredClaims
-	User        *User      `json:"user,omitempty"` // user info
-	SessionOnly bool       `json:"sess_only,omitempty"`
-	Handshake   *Handshake `json:"handshake,omitempty"` // used for oauth handshake
-	NoAva       bool       `json:"no-ava,omitempty"`    // disable avatar, always use identicon
+	User         *User         `json:"user,omitempty"` // user info
+	SessionOnly  bool          `json:"sess_only,omitempty"`
+	Handshake    *Handshake    `json:"handshake,omitempty"`     // used for oauth handshake
+	NoAva        bool          `json:"no-ava,omitempty"`        // disable avatar, always use identicon
+	AuthProvider *AuthProvider `json:"auth_provider,omitempty"` // auth provider info
 }
 
 // Handshake used for oauth handshake
@@ -34,6 +35,11 @@ type Handshake struct {
 	State string `json:"state,omitempty"`
 	From  string `json:"from,omitempty"`
 	ID    string `json:"id,omitempty"`
+}
+
+// AuthProvider stores attributes of provider which has created a JWT token
+type AuthProvider struct {
+	Name string `json:"name,omitempty"`
 }
 
 const (


### PR DESCRIPTION
The problem occurs when the provider name contains underscore characters `_`.
If provider name is like `provider_prod` and full `claims.User.ID`  in the JWT token looks like `provider_prod_user1`,
then [Authenticator.isProviderAllowed()](https://github.com/go-pkgz/auth/blob/master/v2/middleware/auth.go#L156-L167) check fails and provider with such name cannot be used.
This was initially discovered in  https://github.com/go-pkgz/auth/pull/201#discussion_r1624361335.

It might be better to add an explicit provider name into the JWT token claims,
and avoid parsing already serialized string back to tokens.

Provider name passed into `Service.AddProvider()`  also becomes a part of  `https://host:port/auth/provider_prod/login`  URL, and therefore it requires special handling. 
One solution is to url-encode it, but then it will be still possible to use names containing spaces or special characters (by accident or with purpose).
Another solution is to forbid all provider names which require url-encoding.
It might be better to forbid empty names as well.
`_` underscore has been mentioned  in the README examples for some time now, i am not sure about it.
But those names may be even more strict and contain only ASCII alphanumeric symbols.
What do you think?

It is not possible to return errors from `Service.AddProvider()`, therefore invalid providers are just ignored and `ERROR` level message is logged.