### PR TITLE
Fix Content-Type at /logout endpoint

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -298,7 +298,7 @@ func TestLogout(t *testing.T) {
 	resp, err = client.Get("http://127.0.0.1:8089/auth/logout")
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 	defer resp.Body.Close()
 
 	resp, err = client.Get("http://127.0.0.1:8089/private")

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -332,7 +332,7 @@ func (j *Service) Reset(w http.ResponseWriter) {
 		MaxAge: -1, Expires: time.Unix(0, 0), Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &xsrfCookie)
 
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 }
 
 // checkAuds verifies if claims.Audience in the list of allowed by audReader

--- a/v2/auth_test.go
+++ b/v2/auth_test.go
@@ -298,7 +298,7 @@ func TestLogout(t *testing.T) {
 	resp, err = client.Get("http://127.0.0.1:8089/auth/logout")
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 	defer resp.Body.Close()
 
 	resp, err = client.Get("http://127.0.0.1:8089/private")

--- a/v2/token/jwt.go
+++ b/v2/token/jwt.go
@@ -354,7 +354,7 @@ func (j *Service) Reset(w http.ResponseWriter) {
 		MaxAge: -1, Expires: time.Unix(0, 0), Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &xsrfCookie)
 
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 }
 
 // checkAuds verifies if claims.Audience in the list of allowed by audReader


### PR DESCRIPTION
No text is returned so the response is not a valid JSON.

Fix for header introduced in https://github.com/go-pkgz/auth/pull/203, resolves https://github.com/umputun/remark42/issues/1812. I verified the fix locally.