### PR TITLE
Detect and set proper Content-Type for avatars

### DIFF
--- a/avatar/noop_test.go
+++ b/avatar/noop_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +40,7 @@ func TestNoOp_Get(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.Zero(t, resp.ContentLength)
+		assert.Equal(t, "image/*", resp.Header.Get("Content-Type"))
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Empty(t, body)

--- a/v2/avatar/avatar.go
+++ b/v2/avatar/avatar.go
@@ -23,6 +23,9 @@ import (
 	"github.com/go-pkgz/auth/v2/token"
 )
 
+// http.sniffLen is 512 bytes which is how much we need to read to detect content type
+const sniffLen = 512
+
 // Proxy provides http handler for avatars from avatar.Store
 // On user login token will call Put and it will retrieve and save picture locally.
 type Proxy struct {
@@ -100,7 +103,6 @@ func (p *Proxy) load(url string, client *http.Client) (rc io.ReadCloser, err err
 
 // Handler returns token routes for given provider
 func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
-
 	if r.Method != "GET" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
@@ -136,9 +138,25 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	w.Header().Set("Content-Type", "image/*")
+	buf := make([]byte, sniffLen)
+	n, err := avReader.Read(buf)
+	if err != nil && err != io.EOF {
+		p.Logf("[WARN] can't read from avatar reader for %s, %s", avatarID, err)
+		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "can't read avatar")
+		return
+	}
 	w.Header().Set("Content-Length", strconv.Itoa(size))
+	contentType := http.DetectContentType(buf)
+	if contentType == "application/octet-stream" {
+		contentType = "image/*"
+	}
+	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(http.StatusOK)
+	if _, err = w.Write(buf[:n]); err != nil {
+		p.Logf("[WARN] can't write response to %s, %s", r.RemoteAddr, err)
+		return
+	}
+	// write the rest of response size if it's bigger than 512 bytes, or nothing as EOF would be sent right away then
 	if _, err = io.Copy(w, avReader); err != nil {
 		p.Logf("[WARN] can't send response to %s, %s", r.RemoteAddr, err)
 	}

--- a/v2/avatar/noop_test.go
+++ b/v2/avatar/noop_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +40,7 @@ func TestNoOp_Get(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.Zero(t, resp.ContentLength)
+		assert.Equal(t, "image/*", resp.Header.Get("Content-Type"))
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Empty(t, body)


### PR DESCRIPTION
Detect proper avatar type to return instead of returning `image/*`, which is not valid.

Remark42 , before:
```
~ ❯ make rundev
~ ❯ curl -sI -X GET http://127.0.0.1:8083/api/v1/avatar/02625d3d98771929a8a6b1ff4c30628d66389ad6.image | grep Content-Type
Content-Type: image/*
```

Remark42, after:
```
~ ❯ cd backend
~ ❯ go get github.com/go-pkgz/auth@23da433 ; go mod vendor
go: downloading github.com/go-pkgz/auth v1.24.2-0.20240921020949-23da433bf4bb
go: upgraded github.com/go-pkgz/auth v1.24.2-0.20240921014908-825b117d9ed9 => v1.24.2-0.20240921020949-23da433bf4bb
~ ❯ cd ..
~ ❯ make rundev
~ ❯ curl -sI -X GET http://127.0.0.1:8083/api/v1/avatar/02625d3d98771929a8a6b1ff4c30628d66389ad6.image | grep Content-Type
Content-Type: image/png
```