### PR TITLE
Remove extra colon in Direct Authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ In addition to oauth2 providers `auth.Service` allows to use direct user-defined
 
 ```go
 	service.AddDirectProvider("local", provider.CredCheckerFunc(func(user, password string) (ok bool, err error) {
-		ok, err := checkUserSomehow(user, password)
+		ok, err = checkUserSomehow(user, password)
 		return ok, err
 	}))
 ```


### PR DESCRIPTION
Since the variable names are already included in the function declaration, golang will throw an error:
```
no new variables on left side of :=
```