### PR TITLE
docs: recommend pairing with http.CrossOriginProtection for browser apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,32 @@ may be excluded using the `XSRFIgnoreMethods` option. For example, to disable GE
 option to `XSRFIgnoreMethods: []string{"GET"}`. Adding methods other than GET to this list may result
 in XSRF vulnerabilities.
 
+### Browser apps: pair with `http.CrossOriginProtection` (Go 1.25+)
+
+The JWT XSRF check above only fires when the JWT arrives in a cookie and only after a request
+reaches the auth middleware. For browser-based applications it is recommended to additionally
+wrap the router with [`http.CrossOriginProtection`](https://pkg.go.dev/net/http#CrossOriginProtection)
+(Go 1.25+), which checks the browser-set `Sec-Fetch-Site` header (with an `Origin` vs `Host`
+fallback for older clients) and rejects cross-origin state-changing requests at the HTTP layer
+before they reach any handler:
+
+```go
+csrf := http.NewCrossOriginProtection()
+_ = csrf.AddTrustedOrigin("https://app.example.com") // for cross-origin SPAs
+csrf.AddInsecureBypassPattern("POST /auth/apple/")   // Apple Sign In uses form_post
+
+mux := http.NewServeMux()
+mux.Handle("/api/", authenticator.Auth(apiHandler))
+
+log.Fatal(http.ListenAndServe(":8080", csrf.Handler(mux)))
+```
+
+This is the algorithm recommended by [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
+as a primary CSRF defence. Unlike `SameSite=Lax`, it distinguishes _same-origin_ from
+_same-site_, so subdomain attacks are blocked. It composes with the JWT XSRF: the new
+middleware covers browser flows, the JWT XSRF still covers API clients sending the
+JWT-derived header.
+
 ## Status
 
 The library was originally extracted from the [remark42](https://github.com/umputun/remark) project. The code is in production use on multiple sites and has proven to be stable and reliable.


### PR DESCRIPTION
Adds a short README subsection under `## XSRF Protections` recommending that browser-based applications wrap their router with [Go 1.25's `http.CrossOriginProtection`](https://pkg.go.dev/net/http#CrossOriginProtection) in addition to the JWT XSRF check this library already ships.

Documentation only -- no API changes, no new packages, no new dependencies.

### Why

The existing JWT XSRF check (the `XSRF-TOKEN` cookie + `X-XSRF-TOKEN` header pair set by `token.JWT`) is solid but has two gaps for browser-based callers:

1. it only fires when the JWT arrives in a cookie -- requests authenticated via the `X-JWT` header skip the check entirely
2. it operates inside the auth middleware, so cross-origin requests still reach handler code (and any earlier middleware) before being rejected

`Sec-Fetch-Site` is a forbidden header (the browser sets it; JS cannot forge it), shipped in all major browsers since 2023, and OWASP elevated it from defence-in-depth to a primary CSRF defence in [its cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) in December 2025. Unlike `SameSite=Lax`, it distinguishes _same-origin_ from _same-site_, so subdomain attacks are blocked.

The two mechanisms compose naturally: the new middleware covers browser flows at the HTTP layer; the JWT XSRF still covers API clients sending the JWT-derived header.

### What changed

- `README.md` -- new "Browser apps: pair with `http.CrossOriginProtection` (Go 1.25+)" subsection with usage example and rationale

### References

- [Go 1.25 release notes -- net/http.CrossOriginProtection](https://go.dev/doc/go1.25#nethttppkgnethttp)
- [pkg.go.dev -- http.CrossOriginProtection](https://pkg.go.dev/net/http#CrossOriginProtection)
- Filippo Valsorda, [Cross-Site Request Forgery](https://words.filippo.io/csrf/) -- the research the stdlib middleware is based on
- [OWASP CSRF Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
- [Datasette PR #2689](https://github.com/simonw/datasette/pull/2689) -- production migration off CSRF tokens to this algorithm in April 2026