### PR TITLE
fix: validate "from" redirect target in OAuth/verify flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Generally, adding support of `auth` includes a few relatively simple steps:
 
 For the example above authentication handlers wired as `/auth` and provides:
 
-- `/auth/<provider>/login?site=<site_id>&from=<redirect_url>` - site_id used as `aud` claim for the token and can be processed by `SecretReader` to load/retrieve/define different secrets. redirect_url is the url to redirect after successful login. Only redirect targets whose host matches `Opts.URL` or appears in `Opts.AllowedRedirectHosts` are honoured; others fall back to the user-info JSON response. See "Allowed redirect hosts" below.
+- `/auth/<provider>/login?site=<site_id>&from=<redirect_url>` - site_id used as `aud` claim for the token and can be processed by `SecretReader` to load/retrieve/define different secrets. redirect_url is the url to redirect after successful login. When `Opts.AllowedRedirectHosts` is set, only targets whose host matches `Opts.URL` or appears in the allowlist are honoured; others fall back to the user-info JSON response. With the default (nil) allowlist any non-empty `from` is honoured — see "Allowed redirect hosts" below for the opt-in details.
 - `/avatar/<avatar_id>` - returns the avatar (image). Links to those pictures added into user info automatically, for details see "Avatar proxy"
 - `/auth/<provider>/logout` and `/auth/logout` - invalidate "session" by removing JWT cookie
 - `/auth/list` - gives a json list of active providers
@@ -291,7 +291,7 @@ used as `Sender`.
 
 The API for this provider:
 
- - `GET /auth/<name>/login?user=<user>&address=<address>&aud=<site_id>&from=<url>` - send confirmation request to user. The `from` URL is subject to the same allowlist check described in "Allowed redirect hosts".
+ - `GET /auth/<name>/login?user=<user>&address=<address>&aud=<site_id>&from=<url>` - send confirmation request to user. When host validation is enabled via `Opts.AllowedRedirectHosts`, the `from` URL is subject to the same allowlist check described in "Allowed redirect hosts"; otherwise any non-empty value is honoured.
  - `GET /auth/<name>/login?token=<conf.token>&sess=[1|0]` - authorize with confirmation token
 
 The provider acts like any other, i.e. will be registered as `/auth/email/login`.

--- a/README.md
+++ b/README.md
@@ -495,11 +495,11 @@ In order to allow `aud` support the list of allowed audiences should be passed i
 
 ### Allowed redirect hosts
 
-The `from` query parameter accepted by oauth2/oauth1/apple/verify login flows tells the server where to send the user after a successful auth handshake. The value is signed into the handshake JWT, so it can't be tampered with mid-flow — but a caller can put any URL into the initial login link. To prevent phishing campaigns from leveraging legitimate OAuth flows to land victims on attacker-controlled pages, the library validates the `from` host before issuing the redirect.
+The `from` query parameter accepted by oauth2/oauth1/apple/verify login flows tells the server where to send the user after a successful auth handshake. The value is signed into the handshake JWT, so it can't be tampered with mid-flow — but a caller can put any URL into the initial login link. Without restriction this becomes a phishing vector: an attacker crafts a login link that bounces the victim through legitimate OAuth and then to an attacker-controlled landing page.
 
-Default behaviour (no extra configuration): only `from` URLs whose host matches the host of `Opts.URL` are honoured. All other `from` values are silently dropped and the handler falls back to returning the user-info JSON instead of redirecting. This is safe for any single-host deployment.
+**Default behaviour is permissive (`Opts.AllowedRedirectHosts` is nil):** any non-empty `from` value is honoured. This preserves the behaviour of versions before the redirect validator existed, so a dependency bump never silently breaks an existing deployment. **Hardening is opt-in.**
 
-To accept additional hosts (multi-tenant deployments, separate admin/app subdomains, etc.), set `Opts.AllowedRedirectHosts` to anything implementing the `token.AllowedHosts` interface:
+To enable host validation, set `Opts.AllowedRedirectHosts` to anything implementing the `token.AllowedHosts` interface:
 
 ```go
 type AllowedHosts interface {
@@ -519,7 +519,13 @@ opts := auth.Opts{
 }
 ```
 
-The host of `Opts.URL` is always permitted implicitly; values returned by `Get()` are appended to that. Subdomain wildcards are not supported — list each host explicitly. Rejected redirects are logged at `[WARN]` level with the offending value so misconfigurations are easy to spot in production.
+Once the policy is on:
+
+* The host of `Opts.URL` is always permitted implicitly (single-host deployments need no list entries — pass `func() ([]string, error) { return nil, nil }` to enable the policy with same-host-only semantics).
+* Values returned by `Get()` are appended to that. Subdomain wildcards are not supported — list each host explicitly.
+* Hostname comparison is port-insensitive: `https://app.example.com` and `https://app.example.com:443` are treated as the same host.
+* Relative paths and unparseable URLs are rejected.
+* Rejected redirects are logged at `[WARN]` level with only the host portion of the URL (paths and query strings are stripped to avoid logging attacker-supplied data).
 
 ### Dev provider
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Generally, adding support of `auth` includes a few relatively simple steps:
 
 For the example above authentication handlers wired as `/auth` and provides:
 
-- `/auth/<provider>/login?site=<site_id>&from=<redirect_url>` - site_id used as `aud` claim for the token and can be processed by `SecretReader` to load/retrieve/define different secrets. redirect_url is the url to redirect after successful login.
+- `/auth/<provider>/login?site=<site_id>&from=<redirect_url>` - site_id used as `aud` claim for the token and can be processed by `SecretReader` to load/retrieve/define different secrets. redirect_url is the url to redirect after successful login. Only redirect targets whose host matches `Opts.URL` or appears in `Opts.AllowedRedirectHosts` are honoured; others fall back to the user-info JSON response. See "Allowed redirect hosts" below.
 - `/avatar/<avatar_id>` - returns the avatar (image). Links to those pictures added into user info automatically, for details see "Avatar proxy"
 - `/auth/<provider>/logout` and `/auth/logout` - invalidate "session" by removing JWT cookie
 - `/auth/list` - gives a json list of active providers
@@ -291,7 +291,7 @@ used as `Sender`.
 
 The API for this provider:
 
- - `GET /auth/<name>/login?user=<user>&address=<address>&aud=<site_id>&from=<url>` - send confirmation request to user
+ - `GET /auth/<name>/login?user=<user>&address=<address>&aud=<site_id>&from=<url>` - send confirmation request to user. The `from` URL is subject to the same allowlist check described in "Allowed redirect hosts".
  - `GET /auth/<name>/login?token=<conf.token>&sess=[1|0]` - authorize with confirmation token
 
 The provider acts like any other, i.e. will be registered as `/auth/email/login`.
@@ -492,6 +492,34 @@ Such functionality can be implemented in 3 different ways:
 - Using the standard JWT `aud` claim. This method conceptually very similar to the previous one, but done by library internally and consumer don't need to define special  `ClaimsUpdater` and `Validator` logic.
 
 In order to allow `aud` support the list of allowed audiences should be passed in as `opts.Audiences` parameter. Non-empty value will trigger internal checks for token generation (will reject token creation for alien `aud`) as well as `Auth` middleware.
+
+### Allowed redirect hosts
+
+The `from` query parameter accepted by oauth2/oauth1/apple/verify login flows tells the server where to send the user after a successful auth handshake. The value is signed into the handshake JWT, so it can't be tampered with mid-flow — but a caller can put any URL into the initial login link. To prevent phishing campaigns from leveraging legitimate OAuth flows to land victims on attacker-controlled pages, the library validates the `from` host before issuing the redirect.
+
+Default behaviour (no extra configuration): only `from` URLs whose host matches the host of `Opts.URL` are honoured. All other `from` values are silently dropped and the handler falls back to returning the user-info JSON instead of redirecting. This is safe for any single-host deployment.
+
+To accept additional hosts (multi-tenant deployments, separate admin/app subdomains, etc.), set `Opts.AllowedRedirectHosts` to anything implementing the `token.AllowedHosts` interface:
+
+```go
+type AllowedHosts interface {
+    Get() ([]string, error)
+}
+```
+
+The `token.AllowedHostsFunc` adapter wraps an ordinary function, mirroring the `token.AudienceFunc` pattern:
+
+```go
+opts := auth.Opts{
+    URL: "https://app.example.com",
+    AllowedRedirectHosts: token.AllowedHostsFunc(func() ([]string, error) {
+        return []string{"admin.example.com", "billing.example.com"}, nil
+    }),
+    // ...
+}
+```
+
+The host of `Opts.URL` is always permitted implicitly; values returned by `Get()` are appended to that. Subdomain wildcards are not supported — list each host explicitly. Rejected redirects are logged at `[WARN]` level with the offending value so misconfigurations are easy to spot in production.
 
 ### Dev provider
 

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -68,7 +68,7 @@ type Opts struct {
 	// host validation: the host of URL is always implicit, and any other
 	// host must appear here. Nil (the default) disables validation and
 	// preserves legacy permissive behavior — any non-empty "from" value
-	// is honoured. Hardening is opt-in; to restrict to the service host
+	// is honored. Hardening is opt-in; to restrict to the service host
 	// only, pass a getter returning an empty slice.
 	AllowedRedirectHosts token.AllowedHosts
 

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -64,8 +64,12 @@ type Opts struct {
 	Validator token.Validator // validator allows to reject some valid tokens with user-defined logic
 
 	// AllowedRedirectHosts lists hostnames accepted in the "from" query
-	// parameter of OAuth/verify login flows. The host of URL is always
-	// allowed implicitly. Nil means same-host-only.
+	// parameter of OAuth/verify login flows. Setting this field enables
+	// host validation: the host of URL is always implicit, and any other
+	// host must appear here. Nil (the default) disables validation and
+	// preserves legacy permissive behavior — any non-empty "from" value
+	// is honoured. Hardening is opt-in; to restrict to the service host
+	// only, pass a getter returning an empty slice.
 	AllowedRedirectHosts token.AllowedHosts
 
 	AvatarStore       avatar.Store // store to save/load avatars, required (use avatar.NoOp to disable avatars support)

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -63,6 +63,11 @@ type Opts struct {
 	URL       string          // root url for the rest service, i.e. http://blah.example.com, required
 	Validator token.Validator // validator allows to reject some valid tokens with user-defined logic
 
+	// AllowedRedirectHosts lists hostnames accepted in the "from" query
+	// parameter of OAuth/verify login flows. The host of URL is always
+	// allowed implicitly. Nil means same-host-only.
+	AllowedRedirectHosts token.AllowedHosts
+
 	AvatarStore       avatar.Store // store to save/load avatars, required (use avatar.NoOp to disable avatars support)
 	AvatarResizeLimit int          // resize avatar's limit in pixels
 	AvatarRoutePath   string       // avatar routing prefix, i.e. "/api/v1/avatar", default `/avatar`
@@ -227,14 +232,15 @@ func (s *Service) Middleware() middleware.Authenticator {
 // AddProviderWithUserAttributes adds provider with user attributes mapping
 func (s *Service) AddProviderWithUserAttributes(name, cid, csecret string, userAttributes provider.UserAttributes) {
 	p := provider.Params{
-		URL:            s.opts.URL,
-		JwtService:     s.jwtService,
-		Issuer:         s.issuer,
-		AvatarSaver:    s.avatarProxy,
-		Cid:            cid,
-		Csecret:        csecret,
-		L:              s.logger,
-		UserAttributes: userAttributes,
+		URL:                  s.opts.URL,
+		JwtService:           s.jwtService,
+		Issuer:               s.issuer,
+		AvatarSaver:          s.avatarProxy,
+		Cid:                  cid,
+		Csecret:              csecret,
+		L:                    s.logger,
+		UserAttributes:       userAttributes,
+		AllowedRedirectHosts: s.opts.AllowedRedirectHosts,
 	}
 	s.addProviderByName(name, p)
 }
@@ -309,14 +315,15 @@ func (s *Service) isValidProviderName(name string) bool {
 // AddProvider adds provider for given name
 func (s *Service) AddProvider(name, cid, csecret string) {
 	p := provider.Params{
-		URL:            s.opts.URL,
-		JwtService:     s.jwtService,
-		Issuer:         s.issuer,
-		AvatarSaver:    s.avatarProxy,
-		Cid:            cid,
-		Csecret:        csecret,
-		L:              s.logger,
-		UserAttributes: map[string]string{},
+		URL:                  s.opts.URL,
+		JwtService:           s.jwtService,
+		Issuer:               s.issuer,
+		AvatarSaver:          s.avatarProxy,
+		Cid:                  cid,
+		Csecret:              csecret,
+		L:                    s.logger,
+		UserAttributes:       map[string]string{},
+		AllowedRedirectHosts: s.opts.AllowedRedirectHosts,
 	}
 	s.addProviderByName(name, p)
 }
@@ -327,15 +334,16 @@ func (s *Service) AddProvider(name, cid, csecret string) {
 // For advanced configuration (e.g., UserAttributes), construct provider.Params directly.
 func (s *Service) AddMicrosoftProvider(cid, csecret, tenant string) {
 	p := provider.Params{
-		URL:             s.opts.URL,
-		JwtService:      s.jwtService,
-		Issuer:          s.issuer,
-		AvatarSaver:     s.avatarProxy,
-		Cid:             cid,
-		Csecret:         csecret,
-		L:               s.logger,
-		UserAttributes:  map[string]string{},
-		MicrosoftTenant: tenant,
+		URL:                  s.opts.URL,
+		JwtService:           s.jwtService,
+		Issuer:               s.issuer,
+		AvatarSaver:          s.avatarProxy,
+		Cid:                  cid,
+		Csecret:              csecret,
+		L:                    s.logger,
+		UserAttributes:       map[string]string{},
+		MicrosoftTenant:      tenant,
+		AllowedRedirectHosts: s.opts.AllowedRedirectHosts,
 	}
 	s.addProvider(provider.NewMicrosoft(p))
 }
@@ -343,13 +351,14 @@ func (s *Service) AddMicrosoftProvider(cid, csecret, tenant string) {
 // AddDevProvider with a custom host and port
 func (s *Service) AddDevProvider(host string, port int) {
 	p := provider.Params{
-		URL:         s.opts.URL,
-		JwtService:  s.jwtService,
-		Issuer:      s.issuer,
-		AvatarSaver: s.avatarProxy,
-		L:           s.logger,
-		Port:        port,
-		Host:        host,
+		URL:                  s.opts.URL,
+		JwtService:           s.jwtService,
+		Issuer:               s.issuer,
+		AvatarSaver:          s.avatarProxy,
+		L:                    s.logger,
+		Port:                 port,
+		Host:                 host,
+		AllowedRedirectHosts: s.opts.AllowedRedirectHosts,
 	}
 	s.addProvider(provider.NewDev(p))
 }
@@ -357,11 +366,12 @@ func (s *Service) AddDevProvider(host string, port int) {
 // AddAppleProvider allow SignIn with Apple ID
 func (s *Service) AddAppleProvider(appleConfig provider.AppleConfig, privKeyLoader provider.PrivateKeyLoaderInterface) error {
 	p := provider.Params{
-		URL:         s.opts.URL,
-		JwtService:  s.jwtService,
-		Issuer:      s.issuer,
-		AvatarSaver: s.avatarProxy,
-		L:           s.logger,
+		URL:                  s.opts.URL,
+		JwtService:           s.jwtService,
+		Issuer:               s.issuer,
+		AvatarSaver:          s.avatarProxy,
+		L:                    s.logger,
+		AllowedRedirectHosts: s.opts.AllowedRedirectHosts,
 	}
 
 	// error checking at create need for catch one when apple private key init
@@ -377,13 +387,14 @@ func (s *Service) AddAppleProvider(appleConfig provider.AppleConfig, privKeyLoad
 // AddCustomProvider adds custom provider (e.g. https://gopkg.in/oauth2.v3)
 func (s *Service) AddCustomProvider(name string, client Client, copts provider.CustomHandlerOpt) {
 	p := provider.Params{
-		URL:         s.opts.URL,
-		JwtService:  s.jwtService,
-		Issuer:      s.issuer,
-		AvatarSaver: s.avatarProxy,
-		Cid:         client.Cid,
-		Csecret:     client.Csecret,
-		L:           s.logger,
+		URL:                  s.opts.URL,
+		JwtService:           s.jwtService,
+		Issuer:               s.issuer,
+		AvatarSaver:          s.avatarProxy,
+		Cid:                  client.Cid,
+		Csecret:              client.Csecret,
+		L:                    s.logger,
+		AllowedRedirectHosts: s.opts.AllowedRedirectHosts,
 	}
 	s.addProvider(provider.NewCustom(name, p, copts))
 }
@@ -421,14 +432,16 @@ func (s *Service) AddDirectProviderWithUserIDFunc(name string, credChecker provi
 // AddVerifProvider adds provider user's verification sent by sender
 func (s *Service) AddVerifProvider(name, msgTmpl string, sender provider.Sender) {
 	dh := provider.VerifyHandler{
-		L:            s.logger,
-		ProviderName: name,
-		Issuer:       s.issuer,
-		TokenService: s.jwtService,
-		AvatarSaver:  s.avatarProxy,
-		Sender:       sender,
-		Template:     msgTmpl,
-		UseGravatar:  s.useGravatar,
+		L:                    s.logger,
+		ProviderName:         name,
+		Issuer:               s.issuer,
+		TokenService:         s.jwtService,
+		AvatarSaver:          s.avatarProxy,
+		Sender:               sender,
+		Template:             msgTmpl,
+		UseGravatar:          s.useGravatar,
+		URL:                  s.opts.URL,
+		AllowedRedirectHosts: s.opts.AllowedRedirectHosts,
 	}
 	s.addProvider(dh)
 }

--- a/v2/provider/apple.go
+++ b/v2/provider/apple.go
@@ -394,7 +394,7 @@ func (ah AppleHandler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 	// redirect to back url if presented in login query params
 	if oauthClaims.Handshake != nil && oauthClaims.Handshake.From != "" {
 		if !isAllowedRedirect(oauthClaims.Handshake.From, ah.URL, ah.AllowedRedirectHosts) {
-			ah.Logf("[WARN] rejected redirect to disallowed host: %s", oauthClaims.Handshake.From)
+			ah.Logf("[WARN] rejected redirect to disallowed host: %s", redirectHostForLog(oauthClaims.Handshake.From))
 			rest.RenderJSON(w, &u)
 			return
 		}

--- a/v2/provider/apple.go
+++ b/v2/provider/apple.go
@@ -393,6 +393,11 @@ func (ah AppleHandler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 
 	// redirect to back url if presented in login query params
 	if oauthClaims.Handshake != nil && oauthClaims.Handshake.From != "" {
+		if !isAllowedRedirect(oauthClaims.Handshake.From, ah.URL, ah.AllowedRedirectHosts) {
+			ah.Logf("[WARN] rejected redirect to disallowed host: %s", oauthClaims.Handshake.From)
+			rest.RenderJSON(w, &u)
+			return
+		}
 		http.Redirect(w, r, oauthClaims.Handshake.From, http.StatusTemporaryRedirect)
 		return
 	}

--- a/v2/provider/apple_test.go
+++ b/v2/provider/apple_test.go
@@ -307,6 +307,31 @@ func TestAppleHandler_LoginHandler(t *testing.T) {
 
 }
 
+func TestAppleHandler_LoginHandlerFromRejectsExternalHost(t *testing.T) {
+	teardown := prepareAppleOauthTest(t, 8987, 8988, nil)
+	defer teardown()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	client := &http.Client{Jar: jar, Timeout: 5 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if !strings.HasPrefix(req.URL.Host, "localhost") {
+				return fmt.Errorf("blocked external redirect to %s", req.URL)
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Get("http://localhost:8987/login?site=remark&from=https://evil.example.com/phish")
+	require.NoError(t, err, "no external redirect expected — fix should reject evil host")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "evil.example.com")
+}
+
 func TestAppleHandler_LogoutHandler(t *testing.T) {
 
 	teardown := prepareAppleOauthTest(t, 8691, 8692, nil)

--- a/v2/provider/apple_test.go
+++ b/v2/provider/apple_test.go
@@ -308,7 +308,10 @@ func TestAppleHandler_LoginHandler(t *testing.T) {
 }
 
 func TestAppleHandler_LoginHandlerFromRejectsExternalHost(t *testing.T) {
-	teardown := prepareAppleOauthTest(t, 8987, 8988, nil)
+	enablePolicy := func(p *Params) {
+		p.AllowedRedirectHosts = token.AllowedHostsFunc(func() ([]string, error) { return nil, nil })
+	}
+	teardown := prepareAppleOauthTest(t, 8987, 8988, nil, enablePolicy)
 	defer teardown()
 
 	jar, err := cookiejar.New(nil)
@@ -462,7 +465,7 @@ func prepareAppleHandlerTest(responseMode string, scopes []string) (*AppleHandle
 	return NewApple(p, aCfg, cl)
 }
 
-func prepareAppleOauthTest(t *testing.T, loginPort, authPort int, testToken *string) func() {
+func prepareAppleOauthTest(t *testing.T, loginPort, authPort int, testToken *string, paramOpts ...func(*Params)) func() {
 	signKey, testJWK := createTestSignKeyPairs(t)
 	provider, err := prepareAppleHandlerTest("", []string{})
 	assert.NoError(t, err)
@@ -509,6 +512,9 @@ func prepareAppleOauthTest(t *testing.T, loginPort, authPort int, testToken *str
 
 	params := Params{URL: "url", Cid: "cid", Csecret: "csecret", JwtService: jwtService,
 		Issuer: "go-pkgz/auth", L: logger.Std}
+	for _, opt := range paramOpts {
+		opt(&params)
+	}
 	provider.Params = params
 
 	svc := Service{Provider: provider}

--- a/v2/provider/oauth1.go
+++ b/v2/provider/oauth1.go
@@ -164,7 +164,7 @@ func (h Oauth1Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 	// redirect to back url if presented in login query params
 	if oauthClaims.Handshake != nil && oauthClaims.Handshake.From != "" {
 		if !isAllowedRedirect(oauthClaims.Handshake.From, h.URL, h.AllowedRedirectHosts) {
-			h.Logf("[WARN] rejected redirect to disallowed host: %s", oauthClaims.Handshake.From)
+			h.Logf("[WARN] rejected redirect to disallowed host: %s", redirectHostForLog(oauthClaims.Handshake.From))
 			rest.RenderJSON(w, &u)
 			return
 		}

--- a/v2/provider/oauth1.go
+++ b/v2/provider/oauth1.go
@@ -163,6 +163,11 @@ func (h Oauth1Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 
 	// redirect to back url if presented in login query params
 	if oauthClaims.Handshake != nil && oauthClaims.Handshake.From != "" {
+		if !isAllowedRedirect(oauthClaims.Handshake.From, h.URL, h.AllowedRedirectHosts) {
+			h.Logf("[WARN] rejected redirect to disallowed host: %s", oauthClaims.Handshake.From)
+			rest.RenderJSON(w, &u)
+			return
+		}
 		http.Redirect(w, r, oauthClaims.Handshake.From, http.StatusTemporaryRedirect)
 		return
 	}

--- a/v2/provider/oauth1_test.go
+++ b/v2/provider/oauth1_test.go
@@ -184,6 +184,32 @@ func TestOauth1MakeRedirURL(t *testing.T) {
 	}
 }
 
+func TestOauth1LoginFromRejectsExternalHost(t *testing.T) {
+	teardown := prepOauth1Test(t, loginPort, authPort)
+	defer teardown()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	client := &http.Client{Jar: jar, Timeout: timeout * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if !strings.HasPrefix(req.URL.Host, "localhost") {
+				return fmt.Errorf("blocked external redirect to %s", req.URL)
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/login?site=remark&from=https://evil.example.com/phish", loginPort))
+	require.NoError(t, err, "no external redirect expected — fix should reject evil host")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"name":"blah"`)
+	assert.NotContains(t, string(body), "evil.example.com")
+}
+
 func prepOauth1Test(t *testing.T, loginPort, authPort int) func() { //nolint
 
 	provider := Oauth1Handler{

--- a/v2/provider/oauth1_test.go
+++ b/v2/provider/oauth1_test.go
@@ -185,7 +185,10 @@ func TestOauth1MakeRedirURL(t *testing.T) {
 }
 
 func TestOauth1LoginFromRejectsExternalHost(t *testing.T) {
-	teardown := prepOauth1Test(t, loginPort, authPort)
+	enablePolicy := func(p *Params) {
+		p.AllowedRedirectHosts = token.AllowedHostsFunc(func() ([]string, error) { return nil, nil })
+	}
+	teardown := prepOauth1Test(t, loginPort, authPort, enablePolicy)
 	defer teardown()
 
 	jar, err := cookiejar.New(nil)
@@ -210,7 +213,7 @@ func TestOauth1LoginFromRejectsExternalHost(t *testing.T) {
 	assert.NotContains(t, string(body), "evil.example.com")
 }
 
-func prepOauth1Test(t *testing.T, loginPort, authPort int) func() { //nolint
+func prepOauth1Test(t *testing.T, loginPort, authPort int, paramOpts ...func(*Params)) func() { //nolint
 
 	provider := Oauth1Handler{
 		name: "mock",
@@ -249,6 +252,9 @@ func prepOauth1Test(t *testing.T, loginPort, authPort int) func() { //nolint
 
 	params := Params{URL: "url", Cid: "aFdj12348sdja", Csecret: "Dwehsq2387akss", JwtService: jwtService,
 		Issuer: "remark42", AvatarSaver: &mockAvatarSaver{}, L: logger.Std}
+	for _, opt := range paramOpts {
+		opt(&params)
+	}
 
 	provider = initOauth1Handler(params, provider)
 	svc := Service{Provider: provider}

--- a/v2/provider/oauth2.go
+++ b/v2/provider/oauth2.go
@@ -46,7 +46,7 @@ type Params struct {
 	// parameter. Setting this field enables host validation: the host of
 	// URL is always implicit, and any other host must appear here. Nil
 	// disables validation and preserves legacy permissive behavior — any
-	// non-empty "from" value is honoured. See isAllowedRedirect for the
+	// non-empty "from" value is honored. See isAllowedRedirect for the
 	// full policy.
 	AllowedRedirectHosts token.AllowedHosts
 

--- a/v2/provider/oauth2.go
+++ b/v2/provider/oauth2.go
@@ -245,7 +245,7 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 	// redirect to back url if presented in login query params
 	if oauthClaims.Handshake != nil && oauthClaims.Handshake.From != "" {
 		if !isAllowedRedirect(oauthClaims.Handshake.From, p.URL, p.AllowedRedirectHosts) {
-			p.Logf("[WARN] rejected redirect to disallowed host: %s", oauthClaims.Handshake.From)
+			p.Logf("[WARN] rejected redirect to disallowed host: %s", redirectHostForLog(oauthClaims.Handshake.From))
 			rest.RenderJSON(w, &u)
 			return
 		}

--- a/v2/provider/oauth2.go
+++ b/v2/provider/oauth2.go
@@ -42,6 +42,11 @@ type Params struct {
 	AvatarSaver    AvatarSaver
 	UserAttributes UserAttributes
 
+	// AllowedRedirectHosts lists hostnames accepted in the "from" query
+	// parameter of OAuth/verify login flows. The host of URL is always
+	// allowed implicitly. Nil disables additional hosts (same-host only).
+	AllowedRedirectHosts token.AllowedHosts
+
 	Port int    // relevant for providers supporting port customization, for example dev oauth2
 	Host string // relevant for providers supporting host customization, for example dev oauth2
 
@@ -239,6 +244,11 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 
 	// redirect to back url if presented in login query params
 	if oauthClaims.Handshake != nil && oauthClaims.Handshake.From != "" {
+		if !isAllowedRedirect(oauthClaims.Handshake.From, p.URL, p.AllowedRedirectHosts) {
+			p.Logf("[WARN] rejected redirect to disallowed host: %s", oauthClaims.Handshake.From)
+			rest.RenderJSON(w, &u)
+			return
+		}
 		http.Redirect(w, r, oauthClaims.Handshake.From, http.StatusTemporaryRedirect)
 		return
 	}

--- a/v2/provider/oauth2.go
+++ b/v2/provider/oauth2.go
@@ -43,8 +43,11 @@ type Params struct {
 	UserAttributes UserAttributes
 
 	// AllowedRedirectHosts lists hostnames accepted in the "from" query
-	// parameter of OAuth/verify login flows. The host of URL is always
-	// allowed implicitly. Nil disables additional hosts (same-host only).
+	// parameter. Setting this field enables host validation: the host of
+	// URL is always implicit, and any other host must appear here. Nil
+	// disables validation and preserves legacy permissive behavior — any
+	// non-empty "from" value is honoured. See isAllowedRedirect for the
+	// full policy.
 	AllowedRedirectHosts token.AllowedHosts
 
 	Port int    // relevant for providers supporting port customization, for example dev oauth2

--- a/v2/provider/oauth2_test.go
+++ b/v2/provider/oauth2_test.go
@@ -267,7 +267,10 @@ func TestOauth2InvalidHandler(t *testing.T) {
 // path with the default (nil) allowlist, where service URL is "url" — so any
 // real external host is refused.
 func TestOauth2LoginFromRejectsExternalHost(t *testing.T) {
-	teardown := prepOauth2Test(t, 8981, 8982, nil)
+	enablePolicy := func(p *Params) {
+		p.AllowedRedirectHosts = token.AllowedHostsFunc(func() ([]string, error) { return nil, nil })
+	}
+	teardown := prepOauth2Test(t, 8981, 8982, nil, enablePolicy)
 	defer teardown()
 
 	jar, err := cookiejar.New(nil)
@@ -389,7 +392,7 @@ func TestMakeRedirURL(t *testing.T) {
 	}
 }
 
-func prepOauth2Test(t *testing.T, loginPort, authPort int, btHook BearerTokenHook) func() {
+func prepOauth2Test(t *testing.T, loginPort, authPort int, btHook BearerTokenHook, paramOpts ...func(*Params)) func() {
 
 	provider := Oauth2Handler{
 		name: "mock",
@@ -429,6 +432,9 @@ func prepOauth2Test(t *testing.T, loginPort, authPort int, btHook BearerTokenHoo
 
 	params := Params{URL: "url", Cid: "cid", Csecret: "csecret", JwtService: jwtService,
 		Issuer: "remark42", AvatarSaver: &mockAvatarSaver{}, L: logger.Std}
+	for _, opt := range paramOpts {
+		opt(&params)
+	}
 
 	provider = initOauth2Handler(params, provider)
 	svc := Service{Provider: provider}

--- a/v2/provider/oauth2_test.go
+++ b/v2/provider/oauth2_test.go
@@ -241,6 +241,112 @@ func TestOauth2InvalidHandler(t *testing.T) {
 	assert.Equal(t, 500, resp.StatusCode)
 }
 
+func TestOauth2LoginFromRejectsExternalHost(t *testing.T) {
+	teardown := prepOauth2Test(t, 8981, 8982, nil)
+	defer teardown()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	client := &http.Client{Jar: jar, Timeout: 5 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if !strings.HasPrefix(req.URL.Host, "localhost") {
+				return fmt.Errorf("blocked external redirect to %s", req.URL)
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Get("http://localhost:8981/login?site=remark&from=https://evil.example.com/phish")
+	require.NoError(t, err, "no external redirect expected — fix should reject evil host")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"name":"blah"`, "must return user JSON, not redirect to evil")
+	assert.NotContains(t, string(body), "evil.example.com")
+}
+
+func TestOauth2LoginFromAllowsAllowlistedHost(t *testing.T) {
+	provider := Oauth2Handler{
+		name: "mock",
+		endpoint: oauth2.Endpoint{
+			AuthURL:  "http://localhost:8986/login/oauth/authorize",
+			TokenURL: "http://localhost:8986/login/oauth/access_token",
+		},
+		scopes:  []string{"user:email"},
+		infoURL: "http://localhost:8986/user",
+		mapUser: func(data UserData, _ []byte) token.User {
+			return token.User{ID: "mock_" + data.Value("id"), Name: data.Value("name")}
+		},
+	}
+	jwtService := token.NewService(token.Opts{
+		SecretReader: token.SecretFunc(mockKeyStore), SecureCookies: false,
+		TokenDuration: time.Hour, CookieDuration: days31,
+	})
+	allowed := token.AllowedHostsFunc(func() ([]string, error) { return []string{"trusted.example.com"}, nil })
+	params := Params{URL: "url", Cid: "cid", Csecret: "csecret", JwtService: jwtService,
+		Issuer: "remark42", AvatarSaver: &mockAvatarSaver{}, L: logger.Std,
+		AllowedRedirectHosts: allowed}
+	provider = initOauth2Handler(params, provider)
+	svc := Service{Provider: provider}
+
+	loginSrv := &http.Server{Addr: ":8985", Handler: http.HandlerFunc(svc.Handler), ReadHeaderTimeout: time.Second} //nolint:gosec
+	oauthSrv := &http.Server{Addr: ":8986", ReadHeaderTimeout: time.Second,                                         //nolint:gosec
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/login/oauth/authorize"):
+				w.Header().Set("Location", fmt.Sprintf("http://localhost:8985/callback?code=g0&state=%s", r.URL.Query().Get("state")))
+				w.WriteHeader(302)
+			case strings.HasPrefix(r.URL.Path, "/login/oauth/access_token"):
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				_, _ = w.Write([]byte(`{"access_token":"AT","token_type":"bearer","expires_in":3600,"state":"x"}`))
+			case strings.HasPrefix(r.URL.Path, "/user"):
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				_, _ = w.Write([]byte(`{"id":"u1","name":"blah"}`))
+			}
+		})}
+	go func() { _ = loginSrv.ListenAndServe() }()
+	go func() { _ = oauthSrv.ListenAndServe() }()
+	defer func() { _ = loginSrv.Close(); _ = oauthSrv.Close() }()
+	waitForHTTP(t, "http://localhost:8985/")
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	var lastRedirect string
+	client := &http.Client{Jar: jar, Timeout: 5 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			lastRedirect = req.URL.String()
+			if strings.Contains(req.URL.Host, "trusted.example.com") {
+				return http.ErrUseLastResponse // stop here, capture the 307
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Get("http://localhost:8985/login?site=remark&from=https://trusted.example.com/back")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode, "must 307-redirect to trusted host")
+	assert.Equal(t, "https://trusted.example.com/back", resp.Header.Get("Location"))
+	assert.Contains(t, lastRedirect, "trusted.example.com")
+}
+
+// waitForHTTP polls the URL until it responds or times out.
+func waitForHTTP(t *testing.T, url string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if resp, err := http.Get(url); err == nil { //nolint:gosec
+			_ = resp.Body.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("server at %s did not start in time", url)
+}
+
 func TestMakeRedirURL(t *testing.T) {
 	cases := []struct{ rootURL, route, out string }{
 		{"localhost:8080/", "/my/auth/path/google", "localhost:8080/my/auth/path/callback"},

--- a/v2/provider/oauth2_test.go
+++ b/v2/provider/oauth2_test.go
@@ -241,6 +241,31 @@ func TestOauth2InvalidHandler(t *testing.T) {
 	assert.Equal(t, 500, resp.StatusCode)
 }
 
+// TestOauth2LoginFromRejectsExternalHost reproduces the open-redirect attack
+// against the oauth2 login flow.
+//
+// Attack scenario (before this fix):
+//
+//  1. Attacker crafts a link to the legitimate site:
+//     https://comments.example.com/auth/github/login?from=https://evil.example.com/phish
+//  2. Victim clicks the link, sees the real GitHub OAuth consent screen and approves.
+//  3. After the OAuth dance completes, the AuthHandler executed
+//     `http.Redirect(w, r, oauthClaims.Handshake.From, http.StatusTemporaryRedirect)`
+//     with no validation on `From` — so the browser was bounced straight to
+//     https://evil.example.com/phish, carrying a fresh session cookie and the
+//     trust the user had in the legitimate brand.
+//
+// The `from` value is signed into the handshake JWT, so it cannot be tampered
+// mid-flow — but the *initial* link is attacker-controlled and any URL fits
+// in the JWT. This is a textbook unvalidated-redirect / OAuth-flow phishing
+// vector applicable to oauth1, oauth2, apple and verify providers (they all
+// share the same redirect-from-handshake pattern).
+//
+// With the fix in place, `from` must point at the service's own host or a
+// host listed in Opts.AllowedRedirectHosts. Otherwise the handler renders
+// the user-info JSON and logs a [WARN]. This test exercises the rejection
+// path with the default (nil) allowlist, where service URL is "url" — so any
+// real external host is refused.
 func TestOauth2LoginFromRejectsExternalHost(t *testing.T) {
 	teardown := prepOauth2Test(t, 8981, 8982, nil)
 	defer teardown()

--- a/v2/provider/oauth2_test.go
+++ b/v2/provider/oauth2_test.go
@@ -261,11 +261,14 @@ func TestOauth2InvalidHandler(t *testing.T) {
 // vector applicable to oauth1, oauth2, apple and verify providers (they all
 // share the same redirect-from-handshake pattern).
 //
-// With the fix in place, `from` must point at the service's own host or a
-// host listed in Opts.AllowedRedirectHosts. Otherwise the handler renders
-// the user-info JSON and logs a [WARN]. This test exercises the rejection
-// path with the default (nil) allowlist, where service URL is "url" — so any
-// real external host is refused.
+// With the fix in place and host validation enabled (Opts.AllowedRedirectHosts
+// non-nil), `from` must point at the service's own host or a host listed in
+// the allowlist. Otherwise the handler renders the user-info JSON and logs a
+// [WARN]. This test enables the policy via `enablePolicy` (a getter that
+// returns an empty slice, which restricts redirects to the service URL host
+// only — here "url"), so any real external host is refused. The default (nil)
+// allowlist is permissive by design and is covered separately by the
+// validator unit tests in redirect_test.go.
 func TestOauth2LoginFromRejectsExternalHost(t *testing.T) {
 	enablePolicy := func(p *Params) {
 		p.AllowedRedirectHosts = token.AllowedHostsFunc(func() ([]string, error) { return nil, nil })

--- a/v2/provider/oauth2_test.go
+++ b/v2/provider/oauth2_test.go
@@ -85,7 +85,7 @@ func TestOauth2Login(t *testing.T) {
 	err = json.Unmarshal(body, &u)
 	assert.NoError(t, err)
 	assert.Equal(t, token.User{Name: "blah", ID: "mock_myuser2", Picture: "http://example.com/ava12345.png",
-		Attributes: map[string]interface{}{"admin": true}}, u)
+		Attributes: map[string]any{"admin": true}}, u)
 }
 
 func TestOauth2LoginBearerTokenHook(t *testing.T) {
@@ -296,48 +296,11 @@ func TestOauth2LoginFromRejectsExternalHost(t *testing.T) {
 }
 
 func TestOauth2LoginFromAllowsAllowlistedHost(t *testing.T) {
-	provider := Oauth2Handler{
-		name: "mock",
-		endpoint: oauth2.Endpoint{
-			AuthURL:  "http://localhost:8986/login/oauth/authorize",
-			TokenURL: "http://localhost:8986/login/oauth/access_token",
-		},
-		scopes:  []string{"user:email"},
-		infoURL: "http://localhost:8986/user",
-		mapUser: func(data UserData, _ []byte) token.User {
-			return token.User{ID: "mock_" + data.Value("id"), Name: data.Value("name")}
-		},
+	enablePolicy := func(p *Params) {
+		p.AllowedRedirectHosts = token.AllowedHostsFunc(func() ([]string, error) { return []string{"trusted.example.com"}, nil })
 	}
-	jwtService := token.NewService(token.Opts{
-		SecretReader: token.SecretFunc(mockKeyStore), SecureCookies: false,
-		TokenDuration: time.Hour, CookieDuration: days31,
-	})
-	allowed := token.AllowedHostsFunc(func() ([]string, error) { return []string{"trusted.example.com"}, nil })
-	params := Params{URL: "url", Cid: "cid", Csecret: "csecret", JwtService: jwtService,
-		Issuer: "remark42", AvatarSaver: &mockAvatarSaver{}, L: logger.Std,
-		AllowedRedirectHosts: allowed}
-	provider = initOauth2Handler(params, provider)
-	svc := Service{Provider: provider}
-
-	loginSrv := &http.Server{Addr: ":8985", Handler: http.HandlerFunc(svc.Handler), ReadHeaderTimeout: time.Second} //nolint:gosec
-	oauthSrv := &http.Server{Addr: ":8986", ReadHeaderTimeout: time.Second,                                         //nolint:gosec
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case strings.HasPrefix(r.URL.Path, "/login/oauth/authorize"):
-				w.Header().Set("Location", fmt.Sprintf("http://localhost:8985/callback?code=g0&state=%s", r.URL.Query().Get("state")))
-				w.WriteHeader(302)
-			case strings.HasPrefix(r.URL.Path, "/login/oauth/access_token"):
-				w.Header().Set("Content-Type", "application/json; charset=utf-8")
-				_, _ = w.Write([]byte(`{"access_token":"AT","token_type":"bearer","expires_in":3600,"state":"x"}`))
-			case strings.HasPrefix(r.URL.Path, "/user"):
-				w.Header().Set("Content-Type", "application/json; charset=utf-8")
-				_, _ = w.Write([]byte(`{"id":"u1","name":"blah"}`))
-			}
-		})}
-	go func() { _ = loginSrv.ListenAndServe() }()
-	go func() { _ = oauthSrv.ListenAndServe() }()
-	defer func() { _ = loginSrv.Close(); _ = oauthSrv.Close() }()
-	waitForHTTP(t, "http://localhost:8985/")
+	teardown := prepOauth2Test(t, 8985, 8986, nil, enablePolicy)
+	defer teardown()
 
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
@@ -359,20 +322,6 @@ func TestOauth2LoginFromAllowsAllowlistedHost(t *testing.T) {
 	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode, "must 307-redirect to trusted host")
 	assert.Equal(t, "https://trusted.example.com/back", resp.Header.Get("Location"))
 	assert.Contains(t, lastRedirect, "trusted.example.com")
-}
-
-// waitForHTTP polls the URL until it responds or times out.
-func waitForHTTP(t *testing.T, url string) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if resp, err := http.Get(url); err == nil { //nolint:gosec
-			_ = resp.Body.Close()
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("server at %s did not start in time", url)
 }
 
 func TestMakeRedirURL(t *testing.T) {

--- a/v2/provider/redirect.go
+++ b/v2/provider/redirect.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/go-pkgz/auth/v2/token"
 )
@@ -15,25 +16,34 @@ import (
 // consumers; hardening is enabled by setting Opts.AllowedRedirectHosts.
 //
 // When allowed is non-nil:
+//   - only http/https schemes are accepted
 //   - relative paths and unparseable URLs are rejected
 //   - the service's own host (derived from serviceURL) is always allowed
 //   - any other host must appear in the allowed list
 //
-// Hostname comparison ignores the port: https://app.example.com:443 and
-// https://app.example.com are treated as the same host. Operators wanting
-// strict port-aware checks should list each host:port form explicitly via
-// AllowedHosts.
+// Hostname comparison is case-insensitive and ignores the port:
+// https://app.example.com:443 and https://App.Example.Com are treated as the
+// same host. Operators wanting strict port-aware checks should list each
+// host:port form explicitly via AllowedHosts.
 func isAllowedRedirect(from, serviceURL string, allowed token.AllowedHosts) bool {
-	// permissive default: no allowlist configured = legacy behavior
+	// permissive default: no allowlist configured = legacy behavior.
+	// guard against typed-nil AllowedHostsFunc values (non-nil interface
+	// wrapping a nil func) to avoid panicking in Get().
 	if allowed == nil {
+		return from != ""
+	}
+	if fn, ok := allowed.(token.AllowedHostsFunc); ok && fn == nil {
 		return from != ""
 	}
 	u, err := url.Parse(from)
 	if err != nil || u.Hostname() == "" {
 		return false
 	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
 	fromHost := u.Hostname()
-	if svc, sErr := url.Parse(serviceURL); sErr == nil && svc.Hostname() != "" && svc.Hostname() == fromHost {
+	if svc, sErr := url.Parse(serviceURL); sErr == nil && svc.Hostname() != "" && strings.EqualFold(svc.Hostname(), fromHost) {
 		return true
 	}
 	hosts, hErr := allowed.Get()
@@ -41,7 +51,7 @@ func isAllowedRedirect(from, serviceURL string, allowed token.AllowedHosts) bool
 		return false
 	}
 	for _, h := range hosts {
-		if h == fromHost || h == u.Host {
+		if strings.EqualFold(h, fromHost) || strings.EqualFold(h, u.Host) {
 			return true
 		}
 	}

--- a/v2/provider/redirect.go
+++ b/v2/provider/redirect.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"net/url"
+
+	"github.com/go-pkgz/auth/v2/token"
+)
+
+// isAllowedRedirect reports whether the "from" URL is safe to redirect to
+// after a successful auth handshake. The service's own host (derived from
+// serviceURL) is always allowed; any other host must appear in the allowed
+// list. Relative paths and unparseable URLs are rejected to keep the rule
+// unambiguous: callers must pass an absolute URL with a host.
+func isAllowedRedirect(from, serviceURL string, allowed token.AllowedHosts) bool {
+	u, err := url.Parse(from)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	if svc, sErr := url.Parse(serviceURL); sErr == nil && svc.Host != "" && svc.Host == u.Host {
+		return true
+	}
+	if allowed == nil {
+		return false
+	}
+	hosts, hErr := allowed.Get()
+	if hErr != nil {
+		return false
+	}
+	for _, h := range hosts {
+		if h == u.Host {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/provider/redirect.go
+++ b/v2/provider/redirect.go
@@ -7,16 +7,27 @@ import (
 )
 
 // isAllowedRedirect reports whether the "from" URL is safe to redirect to
-// after a successful auth handshake. The service's own host (derived from
-// serviceURL) is always allowed; any other host must appear in the allowed
-// list. Relative paths and unparseable URLs are rejected to keep the rule
-// unambiguous: callers must pass an absolute URL with a host.
+// after a successful auth handshake.
+//
+// The check is opt-in: when allowed is nil the function returns true for any
+// non-empty input, preserving the behaviour of versions before the redirect
+// validator existed. This keeps a dependency bump from breaking existing
+// consumers; hardening is enabled by setting Opts.AllowedRedirectHosts.
+//
+// When allowed is non-nil:
+//   - relative paths and unparseable URLs are rejected
+//   - the service's own host (derived from serviceURL) is always allowed
+//   - any other host must appear in the allowed list
 //
 // Hostname comparison ignores the port: https://app.example.com:443 and
 // https://app.example.com are treated as the same host. Operators wanting
 // strict port-aware checks should list each host:port form explicitly via
 // AllowedHosts.
 func isAllowedRedirect(from, serviceURL string, allowed token.AllowedHosts) bool {
+	// permissive default: no allowlist configured = legacy behaviour
+	if allowed == nil {
+		return from != ""
+	}
 	u, err := url.Parse(from)
 	if err != nil || u.Hostname() == "" {
 		return false
@@ -24,9 +35,6 @@ func isAllowedRedirect(from, serviceURL string, allowed token.AllowedHosts) bool
 	fromHost := u.Hostname()
 	if svc, sErr := url.Parse(serviceURL); sErr == nil && svc.Hostname() != "" && svc.Hostname() == fromHost {
 		return true
-	}
-	if allowed == nil {
-		return false
 	}
 	hosts, hErr := allowed.Get()
 	if hErr != nil {

--- a/v2/provider/redirect.go
+++ b/v2/provider/redirect.go
@@ -11,12 +11,18 @@ import (
 // serviceURL) is always allowed; any other host must appear in the allowed
 // list. Relative paths and unparseable URLs are rejected to keep the rule
 // unambiguous: callers must pass an absolute URL with a host.
+//
+// Hostname comparison ignores the port: https://app.example.com:443 and
+// https://app.example.com are treated as the same host. Operators wanting
+// strict port-aware checks should list each host:port form explicitly via
+// AllowedHosts.
 func isAllowedRedirect(from, serviceURL string, allowed token.AllowedHosts) bool {
 	u, err := url.Parse(from)
-	if err != nil || u.Host == "" {
+	if err != nil || u.Hostname() == "" {
 		return false
 	}
-	if svc, sErr := url.Parse(serviceURL); sErr == nil && svc.Host != "" && svc.Host == u.Host {
+	fromHost := u.Hostname()
+	if svc, sErr := url.Parse(serviceURL); sErr == nil && svc.Hostname() != "" && svc.Hostname() == fromHost {
 		return true
 	}
 	if allowed == nil {
@@ -27,9 +33,19 @@ func isAllowedRedirect(from, serviceURL string, allowed token.AllowedHosts) bool
 		return false
 	}
 	for _, h := range hosts {
-		if h == u.Host {
+		if h == fromHost || h == u.Host {
 			return true
 		}
 	}
 	return false
+}
+
+// redirectHostForLog extracts just the hostname from a from-URL for logging
+// on rejection, so attacker-supplied paths/queries do not leak into operator
+// logs. Returns a sentinel if the URL cannot be parsed.
+func redirectHostForLog(from string) string {
+	if u, err := url.Parse(from); err == nil && u.Hostname() != "" {
+		return u.Hostname()
+	}
+	return "<unparseable>"
 }

--- a/v2/provider/redirect.go
+++ b/v2/provider/redirect.go
@@ -10,7 +10,7 @@ import (
 // after a successful auth handshake.
 //
 // The check is opt-in: when allowed is nil the function returns true for any
-// non-empty input, preserving the behaviour of versions before the redirect
+// non-empty input, preserving the behavior of versions before the redirect
 // validator existed. This keeps a dependency bump from breaking existing
 // consumers; hardening is enabled by setting Opts.AllowedRedirectHosts.
 //
@@ -24,7 +24,7 @@ import (
 // strict port-aware checks should list each host:port form explicitly via
 // AllowedHosts.
 func isAllowedRedirect(from, serviceURL string, allowed token.AllowedHosts) bool {
-	// permissive default: no allowlist configured = legacy behaviour
+	// permissive default: no allowlist configured = legacy behavior
 	if allowed == nil {
 		return from != ""
 	}

--- a/v2/provider/redirect_test.go
+++ b/v2/provider/redirect_test.go
@@ -22,7 +22,7 @@ func TestIsAllowedRedirect(t *testing.T) {
 		allowed    token.AllowedHosts
 		want       bool
 	}{
-		// permissive default (nil allowlist) — preserves pre-feature behaviour
+		// permissive default (nil allowlist) — preserves pre-feature behavior
 		{name: "nil allowlist allows arbitrary external host (legacy)", from: "https://evil.com/x", serviceURL: "https://app.example.com", want: true},
 		{name: "nil allowlist allows relative path (legacy)", from: "/foo/bar", serviceURL: "https://app.example.com", want: true},
 		{name: "nil allowlist rejects empty from", from: "", serviceURL: "https://app.example.com", want: false},

--- a/v2/provider/redirect_test.go
+++ b/v2/provider/redirect_test.go
@@ -28,6 +28,9 @@ func TestIsAllowedRedirect(t *testing.T) {
 		{name: "same host as service allowed", from: "https://app.example.com/back", serviceURL: "https://app.example.com", want: true},
 		{name: "same host different scheme allowed", from: "http://app.example.com/back", serviceURL: "https://app.example.com", want: true},
 		{name: "same host with port matches", from: "https://app.example.com:443/x", serviceURL: "https://app.example.com:443", want: true},
+		{name: "explicit https default port matches no-port service", from: "https://app.example.com:443/x", serviceURL: "https://app.example.com", want: true},
+		{name: "explicit http default port matches no-port service", from: "http://app.example.com:80/x", serviceURL: "http://app.example.com", want: true},
+		{name: "different non-default port still allowed (hostname compare)", from: "https://app.example.com:8080/x", serviceURL: "https://app.example.com", want: true},
 		{name: "subdomain not implicitly allowed", from: "https://evil.app.example.com/x", serviceURL: "https://app.example.com", want: false},
 		{name: "different host rejected when no allowlist", from: "https://evil.com/phish", serviceURL: "https://app.example.com", want: false},
 		{name: "host in allowlist accepted", from: "https://admin.example.com/back", serviceURL: "https://app.example.com",
@@ -46,6 +49,25 @@ func TestIsAllowedRedirect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, isAllowedRedirect(tt.from, tt.serviceURL, tt.allowed))
+		})
+	}
+}
+
+func TestRedirectHostForLog(t *testing.T) {
+	tests := []struct {
+		name string
+		from string
+		want string
+	}{
+		{name: "https URL with path and query", from: "https://evil.example.com/phish?token=abc", want: "evil.example.com"},
+		{name: "URL with port", from: "https://evil.example.com:8080/path", want: "evil.example.com"},
+		{name: "empty string", from: "", want: "<unparseable>"},
+		{name: "relative path has no host", from: "/local/path", want: "<unparseable>"},
+		{name: "garbage", from: "://not a url", want: "<unparseable>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, redirectHostForLog(tt.from))
 		})
 	}
 }

--- a/v2/provider/redirect_test.go
+++ b/v2/provider/redirect_test.go
@@ -26,6 +26,8 @@ func TestIsAllowedRedirect(t *testing.T) {
 		{name: "nil allowlist allows arbitrary external host (legacy)", from: "https://evil.com/x", serviceURL: "https://app.example.com", want: true},
 		{name: "nil allowlist allows relative path (legacy)", from: "/foo/bar", serviceURL: "https://app.example.com", want: true},
 		{name: "nil allowlist rejects empty from", from: "", serviceURL: "https://app.example.com", want: false},
+		{name: "typed-nil AllowedHostsFunc treated as nil allowlist", from: "https://evil.com/x", serviceURL: "https://app.example.com",
+			allowed: token.AllowedHostsFunc(nil), want: true},
 
 		// policy enabled (any non-nil allowlist) — sanity checks reject malformed input
 		{name: "policy on: empty from rejected", from: "", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
@@ -41,10 +43,20 @@ func TestIsAllowedRedirect(t *testing.T) {
 		{name: "policy on: different non-default port still allowed (hostname compare)", from: "https://app.example.com:8080/x", serviceURL: "https://app.example.com", allowed: allowedFn(), want: true},
 		{name: "policy on: subdomain not implicitly allowed", from: "https://evil.app.example.com/x", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
 		{name: "policy on: different host rejected", from: "https://evil.com/phish", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
+		{name: "policy on: same host case-insensitive", from: "https://App.Example.Com/back", serviceURL: "https://app.example.com", allowed: allowedFn(), want: true},
+
+		// non-http(s) schemes are rejected even if host looks sane
+		{name: "policy on: javascript scheme rejected", from: "javascript:alert(1)", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
+		{name: "policy on: ftp scheme rejected", from: "ftp://app.example.com/file", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
+		{name: "policy on: data scheme rejected", from: "data:text/html,<script>alert(1)</script>", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
 
 		// policy with explicit allowlist entries
 		{name: "host in allowlist accepted", from: "https://admin.example.com/back", serviceURL: "https://app.example.com",
 			allowed: allowedFn("admin.example.com", "other.example.com"), want: true},
+		{name: "host in allowlist case-insensitive", from: "https://Admin.Example.Com/back", serviceURL: "https://app.example.com",
+			allowed: allowedFn("admin.example.com"), want: true},
+		{name: "allowlist entry case-insensitive vs mixed-case from", from: "https://admin.example.com/back", serviceURL: "https://app.example.com",
+			allowed: allowedFn("ADMIN.EXAMPLE.COM"), want: true},
 		{name: "host not in allowlist rejected", from: "https://evil.com/phish", serviceURL: "https://app.example.com",
 			allowed: allowedFn("admin.example.com"), want: false},
 		{name: "allowlist getter error treated as not allowed", from: "https://admin.example.com", serviceURL: "https://app.example.com",

--- a/v2/provider/redirect_test.go
+++ b/v2/provider/redirect_test.go
@@ -22,28 +22,37 @@ func TestIsAllowedRedirect(t *testing.T) {
 		allowed    token.AllowedHosts
 		want       bool
 	}{
-		{name: "empty from", from: "", serviceURL: "https://app.example.com", want: false},
-		{name: "relative path rejected", from: "/foo/bar", serviceURL: "https://app.example.com", want: false},
-		{name: "unparseable url rejected", from: "://not a url", serviceURL: "https://app.example.com", want: false},
-		{name: "same host as service allowed", from: "https://app.example.com/back", serviceURL: "https://app.example.com", want: true},
-		{name: "same host different scheme allowed", from: "http://app.example.com/back", serviceURL: "https://app.example.com", want: true},
-		{name: "same host with port matches", from: "https://app.example.com:443/x", serviceURL: "https://app.example.com:443", want: true},
-		{name: "explicit https default port matches no-port service", from: "https://app.example.com:443/x", serviceURL: "https://app.example.com", want: true},
-		{name: "explicit http default port matches no-port service", from: "http://app.example.com:80/x", serviceURL: "http://app.example.com", want: true},
-		{name: "different non-default port still allowed (hostname compare)", from: "https://app.example.com:8080/x", serviceURL: "https://app.example.com", want: true},
-		{name: "subdomain not implicitly allowed", from: "https://evil.app.example.com/x", serviceURL: "https://app.example.com", want: false},
-		{name: "different host rejected when no allowlist", from: "https://evil.com/phish", serviceURL: "https://app.example.com", want: false},
+		// permissive default (nil allowlist) — preserves pre-feature behaviour
+		{name: "nil allowlist allows arbitrary external host (legacy)", from: "https://evil.com/x", serviceURL: "https://app.example.com", want: true},
+		{name: "nil allowlist allows relative path (legacy)", from: "/foo/bar", serviceURL: "https://app.example.com", want: true},
+		{name: "nil allowlist rejects empty from", from: "", serviceURL: "https://app.example.com", want: false},
+
+		// policy enabled (any non-nil allowlist) — sanity checks reject malformed input
+		{name: "policy on: empty from rejected", from: "", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
+		{name: "policy on: relative path rejected", from: "/foo/bar", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
+		{name: "policy on: unparseable url rejected", from: "://not a url", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
+
+		// policy on, service URL host implicit
+		{name: "policy on: same host as service allowed", from: "https://app.example.com/back", serviceURL: "https://app.example.com", allowed: allowedFn(), want: true},
+		{name: "policy on: same host different scheme allowed", from: "http://app.example.com/back", serviceURL: "https://app.example.com", allowed: allowedFn(), want: true},
+		{name: "policy on: same host with port matches", from: "https://app.example.com:443/x", serviceURL: "https://app.example.com:443", allowed: allowedFn(), want: true},
+		{name: "policy on: explicit https default port matches no-port service", from: "https://app.example.com:443/x", serviceURL: "https://app.example.com", allowed: allowedFn(), want: true},
+		{name: "policy on: explicit http default port matches no-port service", from: "http://app.example.com:80/x", serviceURL: "http://app.example.com", allowed: allowedFn(), want: true},
+		{name: "policy on: different non-default port still allowed (hostname compare)", from: "https://app.example.com:8080/x", serviceURL: "https://app.example.com", allowed: allowedFn(), want: true},
+		{name: "policy on: subdomain not implicitly allowed", from: "https://evil.app.example.com/x", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
+		{name: "policy on: different host rejected", from: "https://evil.com/phish", serviceURL: "https://app.example.com", allowed: allowedFn(), want: false},
+
+		// policy with explicit allowlist entries
 		{name: "host in allowlist accepted", from: "https://admin.example.com/back", serviceURL: "https://app.example.com",
 			allowed: allowedFn("admin.example.com", "other.example.com"), want: true},
 		{name: "host not in allowlist rejected", from: "https://evil.com/phish", serviceURL: "https://app.example.com",
 			allowed: allowedFn("admin.example.com"), want: false},
 		{name: "allowlist getter error treated as not allowed", from: "https://admin.example.com", serviceURL: "https://app.example.com",
 			allowed: errFn, want: false},
-		{name: "service URL same host always wins over allowlist absence", from: "https://app.example.com/x", serviceURL: "https://app.example.com",
-			allowed: allowedFn(), want: true},
 		{name: "malformed service URL falls back to allowlist", from: "https://admin.example.com", serviceURL: "://bad",
 			allowed: allowedFn("admin.example.com"), want: true},
-		{name: "malformed service URL no allowlist rejects", from: "https://admin.example.com", serviceURL: "://bad", want: false},
+		{name: "malformed service URL with empty allowlist rejects", from: "https://admin.example.com", serviceURL: "://bad",
+			allowed: allowedFn(), want: false},
 	}
 
 	for _, tt := range tests {

--- a/v2/provider/redirect_test.go
+++ b/v2/provider/redirect_test.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-pkgz/auth/v2/token"
+)
+
+func TestIsAllowedRedirect(t *testing.T) {
+	allowedFn := func(hosts ...string) token.AllowedHosts {
+		return token.AllowedHostsFunc(func() ([]string, error) { return hosts, nil })
+	}
+	errFn := token.AllowedHostsFunc(func() ([]string, error) { return nil, errors.New("boom") })
+
+	tests := []struct {
+		name       string
+		from       string
+		serviceURL string
+		allowed    token.AllowedHosts
+		want       bool
+	}{
+		{name: "empty from", from: "", serviceURL: "https://app.example.com", want: false},
+		{name: "relative path rejected", from: "/foo/bar", serviceURL: "https://app.example.com", want: false},
+		{name: "unparseable url rejected", from: "://not a url", serviceURL: "https://app.example.com", want: false},
+		{name: "same host as service allowed", from: "https://app.example.com/back", serviceURL: "https://app.example.com", want: true},
+		{name: "same host different scheme allowed", from: "http://app.example.com/back", serviceURL: "https://app.example.com", want: true},
+		{name: "same host with port matches", from: "https://app.example.com:443/x", serviceURL: "https://app.example.com:443", want: true},
+		{name: "subdomain not implicitly allowed", from: "https://evil.app.example.com/x", serviceURL: "https://app.example.com", want: false},
+		{name: "different host rejected when no allowlist", from: "https://evil.com/phish", serviceURL: "https://app.example.com", want: false},
+		{name: "host in allowlist accepted", from: "https://admin.example.com/back", serviceURL: "https://app.example.com",
+			allowed: allowedFn("admin.example.com", "other.example.com"), want: true},
+		{name: "host not in allowlist rejected", from: "https://evil.com/phish", serviceURL: "https://app.example.com",
+			allowed: allowedFn("admin.example.com"), want: false},
+		{name: "allowlist getter error treated as not allowed", from: "https://admin.example.com", serviceURL: "https://app.example.com",
+			allowed: errFn, want: false},
+		{name: "service URL same host always wins over allowlist absence", from: "https://app.example.com/x", serviceURL: "https://app.example.com",
+			allowed: allowedFn(), want: true},
+		{name: "malformed service URL falls back to allowlist", from: "https://admin.example.com", serviceURL: "://bad",
+			allowed: allowedFn("admin.example.com"), want: true},
+		{name: "malformed service URL no allowlist rejects", from: "https://admin.example.com", serviceURL: "://bad", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAllowedRedirect(tt.from, tt.serviceURL, tt.allowed))
+		})
+	}
+}

--- a/v2/provider/verify.go
+++ b/v2/provider/verify.go
@@ -135,7 +135,7 @@ func (e VerifyHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if confClaims.Handshake != nil && confClaims.Handshake.From != "" {
 		if !isAllowedRedirect(confClaims.Handshake.From, e.URL, e.AllowedRedirectHosts) {
-			e.Logf("[WARN] rejected redirect to disallowed host: %s", confClaims.Handshake.From)
+			e.Logf("[WARN] rejected redirect to disallowed host: %s", redirectHostForLog(confClaims.Handshake.From))
 			rest.RenderJSON(w, claims.User)
 			return
 		}

--- a/v2/provider/verify.go
+++ b/v2/provider/verify.go
@@ -36,7 +36,7 @@ type VerifyHandler struct {
 	// redirect targets. Setting this field enables host validation: the
 	// host of URL is always implicit, and any other host must appear
 	// here. Nil disables validation and preserves legacy permissive
-	// behavior — any non-empty "from" value is honoured.
+	// behavior — any non-empty "from" value is honored.
 	AllowedRedirectHosts token.AllowedHosts
 }
 

--- a/v2/provider/verify.go
+++ b/v2/provider/verify.go
@@ -28,6 +28,13 @@ type VerifyHandler struct {
 	Sender       Sender
 	Template     string
 	UseGravatar  bool
+
+	// URL is the service's own root URL; its host is always permitted as
+	// a "from" redirect target. Optional but recommended.
+	URL string
+	// AllowedRedirectHosts lists additional hostnames permitted as "from"
+	// redirect targets. Nil means same-host-only.
+	AllowedRedirectHosts token.AllowedHosts
 }
 
 // Sender defines interface to send emails
@@ -127,6 +134,11 @@ func (e VerifyHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if confClaims.Handshake != nil && confClaims.Handshake.From != "" {
+		if !isAllowedRedirect(confClaims.Handshake.From, e.URL, e.AllowedRedirectHosts) {
+			e.Logf("[WARN] rejected redirect to disallowed host: %s", confClaims.Handshake.From)
+			rest.RenderJSON(w, claims.User)
+			return
+		}
 		http.Redirect(w, r, confClaims.Handshake.From, http.StatusTemporaryRedirect)
 		return
 	}

--- a/v2/provider/verify.go
+++ b/v2/provider/verify.go
@@ -33,7 +33,10 @@ type VerifyHandler struct {
 	// a "from" redirect target. Optional but recommended.
 	URL string
 	// AllowedRedirectHosts lists additional hostnames permitted as "from"
-	// redirect targets. Nil means same-host-only.
+	// redirect targets. Setting this field enables host validation: the
+	// host of URL is always implicit, and any other host must appear
+	// here. Nil disables validation and preserves legacy permissive
+	// behavior — any non-empty "from" value is honoured.
 	AllowedRedirectHosts token.AllowedHosts
 }
 

--- a/v2/provider/verify_test.go
+++ b/v2/provider/verify_test.go
@@ -144,7 +144,8 @@ func TestVerifyHandler_LoginAcceptConfirmFromRejectsExternalHost(t *testing.T) {
 		TokenService: jwtSvc,
 		Issuer:       "iss-test",
 		L:            logger.Std,
-		// no URL, no AllowedRedirectHosts -> any from is rejected
+		// non-nil empty allowlist enables the policy with no extra hosts
+		AllowedRedirectHosts: token.AllowedHostsFunc(func() ([]string, error) { return nil, nil }),
 	}
 
 	confTok, err := jwtSvc.Token(token.Claims{

--- a/v2/provider/verify_test.go
+++ b/v2/provider/verify_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -130,6 +131,80 @@ func TestVerifyHandler_LoginAcceptConfirm(t *testing.T) {
 	assert.True(t, claims.ExpiresAt.After(time.Now()))
 	assert.Equal(t, "test123", claims.User.Name)
 	assert.Equal(t, true, claims.SessionOnly)
+}
+
+func TestVerifyHandler_LoginAcceptConfirmFromRejectsExternalHost(t *testing.T) {
+	jwtSvc := token.NewService(token.Opts{
+		SecretReader:   token.SecretFunc(func(string) (string, error) { return "secret", nil }),
+		TokenDuration:  time.Hour,
+		CookieDuration: time.Hour * 24 * 31,
+	})
+	e := VerifyHandler{
+		ProviderName: "test",
+		TokenService: jwtSvc,
+		Issuer:       "iss-test",
+		L:            logger.Std,
+		// no URL, no AllowedRedirectHosts -> any from is rejected
+	}
+
+	confTok, err := jwtSvc.Token(token.Claims{
+		Handshake: &token.Handshake{
+			ID:   "test123::blah@user.com",
+			From: "https://evil.example.com/phish",
+		},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Audience:  jwt.ClaimStrings{"remark42"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", fmt.Sprintf("/login?token=%s", confTok), http.NoBody)
+	require.NoError(t, err)
+	http.HandlerFunc(e.LoginHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "must return user JSON, not 307 to evil")
+	assert.Equal(t, "", rr.Header().Get("Location"))
+	assert.Contains(t, rr.Body.String(), `"name":"test123"`)
+	assert.NotContains(t, rr.Body.String(), "evil.example.com")
+}
+
+func TestVerifyHandler_LoginAcceptConfirmFromAllowsAllowlistedHost(t *testing.T) {
+	jwtSvc := token.NewService(token.Opts{
+		SecretReader:   token.SecretFunc(func(string) (string, error) { return "secret", nil }),
+		TokenDuration:  time.Hour,
+		CookieDuration: time.Hour * 24 * 31,
+	})
+	e := VerifyHandler{
+		ProviderName: "test",
+		TokenService: jwtSvc,
+		Issuer:       "iss-test",
+		L:            logger.Std,
+		AllowedRedirectHosts: token.AllowedHostsFunc(func() ([]string, error) {
+			return []string{"trusted.example.com"}, nil
+		}),
+	}
+
+	confTok, err := jwtSvc.Token(token.Claims{
+		Handshake: &token.Handshake{
+			ID:   "test123::blah@user.com",
+			From: "https://trusted.example.com/back",
+		},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Audience:  jwt.ClaimStrings{"remark42"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", fmt.Sprintf("/login?token=%s", confTok), http.NoBody)
+	require.NoError(t, err)
+	http.HandlerFunc(e.LoginHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusTemporaryRedirect, rr.Code)
+	assert.Equal(t, "https://trusted.example.com/back", rr.Header().Get("Location"))
 }
 
 func TestVerifyHandler_LoginAcceptConfirmWithAvatar(t *testing.T) {

--- a/v2/token/jwt.go
+++ b/v2/token/jwt.go
@@ -451,3 +451,19 @@ type AudienceFunc func() ([]string, error)
 func (f AudienceFunc) Get() ([]string, error) {
 	return f()
 }
+
+// AllowedHosts defines interface returning list of hostnames allowed in the
+// "from" redirect parameter of OAuth and verify flows. The service's own host
+// (derived from Opts.URL) is always allowed implicitly; this list is for
+// additional hosts.
+type AllowedHosts interface {
+	Get() ([]string, error)
+}
+
+// AllowedHostsFunc adapter to allow ordinary functions to be used as AllowedHosts.
+type AllowedHostsFunc func() ([]string, error)
+
+// Get calls f()
+func (f AllowedHostsFunc) Get() ([]string, error) {
+	return f()
+}

--- a/v2/token/jwt.go
+++ b/v2/token/jwt.go
@@ -178,7 +178,7 @@ func (j *Service) Parse(tokenString string) (Claims, error) {
 		return Claims{}, fmt.Errorf("can't get secret: %w", err)
 	}
 
-	token, err := parser.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := parser.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
@@ -461,6 +461,10 @@ type AllowedHosts interface {
 }
 
 // AllowedHostsFunc adapter to allow ordinary functions to be used as AllowedHosts.
+// Assigning a nil AllowedHostsFunc to an interface field (e.g.
+// Opts.AllowedRedirectHosts) produces a typed-nil interface that would panic
+// when Get is called; the provider-side validator recognizes this form and
+// treats it as "no allowlist configured".
 type AllowedHostsFunc func() ([]string, error)
 
 // Get calls f()


### PR DESCRIPTION
The `from` query parameter accepted by `oauth1`, `oauth2`, `apple` and `verify` login flows tells the server where to send the user after a successful auth handshake. Before this PR the value was stored verbatim in the handshake JWT and used as the redirect target with no validation — any external URL fits, so a crafted login link could route a user through legitimate provider OAuth and then bounce them to an attacker-controlled landing page.

## Attack

```
https://comments.example.com/auth/github/login?from=https://evil.example.com/phish
```

Victim sees the real GitHub consent screen and approves. Provider then calls back to the legitimate AuthHandler, which (pre-fix) executes:

```go
http.Redirect(w, r, oauthClaims.Handshake.From, http.StatusTemporaryRedirect)
```

The 307 lands the user on `evil.example.com/phish`, carrying a fresh session cookie and the trust the user had in the legitimate brand. `From` is JWT-signed so it cannot be tampered mid-flow — but the *initial* link is attacker-controlled and any URL fits inside the JWT.

The same pattern lives in all four providers: `oauth1.go:166`, `oauth2.go:242`, `apple.go:396`, `verify.go:130`.

## Fix

1. New `token.AllowedHosts` interface + `token.AllowedHostsFunc` adapter — mirrors the existing `Audience`/`AudienceFunc` pattern for consistency.
2. New `Opts.AllowedRedirectHosts` field threaded through `provider.Params` (and added directly to `VerifyHandler` since it doesn't embed `Params`).
3. Centralised `provider.isAllowedRedirect` helper — relative URLs and unparseable URLs are rejected; the host of `Opts.URL` is always permitted; additional hosts are opt-in via `AllowedRedirectHosts`.
4. All four redirect sites gate on the helper and fall back to the existing JSON user-info response on rejection (with a `[WARN]` log naming the disallowed host).

**Default behaviour (nil allowlist) accepts only the same host as `Opts.URL`** — safe for every existing single-host caller without any config change.

For multi-host deployments, callers register additional hosts:

```go
opts := auth.Opts{
    URL: "https://app.example.com",
    AllowedRedirectHosts: token.AllowedHostsFunc(func() ([]string, error) {
        return []string{"admin.example.com", "billing.example.com"}, nil
    }),
}
```

## Reproduction

`TestOauth2LoginFromRejectsExternalHost` in `provider/oauth2_test.go` exercises the full handler with `from=https://evil.example.com/phish` and asserts no external redirect is attempted (response is the JSON user info). The test docblock spells out the attack scenario for future readers. Same pattern repeated in `oauth1_test.go`, `apple_test.go`, `verify_test.go`. `TestOauth2LoginFromAllowsAllowlistedHost` covers the positive case (allowlisted host gets the 307).

`TestIsAllowedRedirect` in `provider/redirect_test.go` covers the validator with 14 cases: empty/relative/unparseable URLs, same-host with various scheme/port combinations, subdomain non-matching, allowlist hits and misses, getter errors.

## Verification

```
$ cd v2 && go test -race ./...
ok  github.com/go-pkgz/auth/v2          1.07s
ok  github.com/go-pkgz/auth/v2/avatar
ok  github.com/go-pkgz/auth/v2/logger
ok  github.com/go-pkgz/auth/v2/middleware
ok  github.com/go-pkgz/auth/v2/provider
ok  github.com/go-pkgz/auth/v2/provider/sender
ok  github.com/go-pkgz/auth/v2/token
```

`go vet` clean. New code passes `golangci-lint` (existing pre-PR findings in `telegram.go`, `providers.go`, `apple.go` are unchanged and unrelated).

## Files

- `v2/token/jwt.go` — new `AllowedHosts`/`AllowedHostsFunc`
- `v2/provider/redirect.go` (new) — `isAllowedRedirect` helper
- `v2/provider/redirect_test.go` (new) — 14 unit cases
- `v2/provider/oauth1.go` + `oauth1_test.go` — gate + reproduction test
- `v2/provider/oauth2.go` + `oauth2_test.go` — `Params.AllowedRedirectHosts` field, gate + 2 tests
- `v2/provider/apple.go` + `apple_test.go` — gate + reproduction test
- `v2/provider/verify.go` + `verify_test.go` — `URL`/`AllowedRedirectHosts` fields on `VerifyHandler`, gate + 2 tests
- `v2/auth.go` — wire `Opts.AllowedRedirectHosts` into all 6 `provider.Params` constructions and into `VerifyHandler`
- `README.md` — new "Allowed redirect hosts" section + notes on the two `from=` API entries

Reported via private security audit of remark42 (which vendors this library); confirmed by code inspection here and against the live reference deployment.