### PR TITLE
docs(verify): caveat that email proves control, not stable identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,24 @@ The API for this provider:
 
 The provider acts like any other, i.e. will be registered as `/auth/email/login`.
 
+#### Email-as-identity caveat
+
+The verify provider returns a local user id of the form `<provider>_<sha1(address)>`. The confirmation round-trip proves current control of the address at the moment of login; it does **not** prove stable+unique identity over time. The owner of an address can change without the address changing:
+
+- **Employer offboarding** — `alice@example-corp.com` returns to the company when Alice leaves and may be reassigned to a new employee.
+- **Lapsed free-mail accounts** — providers reclaim and recycle inactive mailboxes; the next person who registers the same handle inherits any service that keys on the address.
+- **Domain recycling** — when a personal domain is not renewed and is re-registered, the new owner can receive mail for every local part it ever had.
+
+This is inherent to email-as-identity, not specific to this library — the verify flow has no upstream identifier (such as an OIDC `sub`) it could fall back on. Any application that keys its own records directly on the returned id will treat the new owner of an address as the original user.
+
+Integrators that need stable identity should:
+
+- Map the verified address to a server-side immutable user id (e.g., a `users` table primary key) at first successful verify, and key application records, ACLs, and audit logs on that internal id rather than on the value returned by the provider.
+- Treat a verified address whose internal id is missing as a new account, not as a reactivation of an old one.
+- For higher-stakes systems, consider re-verification policies (re-prove address control after long inactivity) and reuse-detection signals before granting access to historical data.
+
+If your threat model accepts that whoever currently controls an address gets the corresponding account (e.g. low-stakes commenting), no extra handling is required — but the property should be a deliberate choice, not an inherited default.
+
 ### Email
 
 For email notify provider, please use `github.com/go-pkgz/auth/provider/sender` package:

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -19,6 +19,18 @@ import (
 
 // VerifyHandler implements non-oauth2 provider authorizing users with some confirmation.
 // can be email, IM or anything else implementing Sender interface
+//
+// Identity caveat: the local user id returned to the application is derived
+// from the verified address (ProviderName + "_" + HashID(address)). The
+// confirmation round-trip proves current control of the address at login
+// time; it does not guarantee a stable+unique identity over time. The owner
+// of an address can change without the address changing — employer
+// offboarding, lapsed free-mail accounts, and recycled domains all hand
+// control of an address to the next person who claims it. Integrators that
+// need stable identity should map the verified address to a server-side
+// immutable user id at first successful verify and key their records on
+// that id, not on the value returned here. See the "Email-as-identity
+// caveat" section of the README for guidance.
 type VerifyHandler struct {
 	logger.L
 	ProviderName string

--- a/v2/provider/verify.go
+++ b/v2/provider/verify.go
@@ -19,6 +19,18 @@ import (
 
 // VerifyHandler implements non-oauth2 provider authorizing users with some confirmation.
 // can be email, IM or anything else implementing Sender interface
+//
+// Identity caveat: the local user id returned to the application is derived
+// from the verified address (ProviderName + "_" + HashID(address)). The
+// confirmation round-trip proves current control of the address at login
+// time; it does not guarantee a stable+unique identity over time. The owner
+// of an address can change without the address changing — employer
+// offboarding, lapsed free-mail accounts, and recycled domains all hand
+// control of an address to the next person who claims it. Integrators that
+// need stable identity should map the verified address to a server-side
+// immutable user id at first successful verify and key their records on
+// that id, not on the value returned here. See the "Email-as-identity
+// caveat" section of the README for guidance.
 type VerifyHandler struct {
 	logger.L
 	ProviderName string


### PR DESCRIPTION
### Summary

The `verify` provider derives the local user id from the verified address:

```go
u := token.User{
    Name: user,
    ID:   e.ProviderName + "_" + token.HashID(sha1.New(), address),
}
```

The confirmation round-trip proves current control of the address at login time, but it does **not** guarantee a stable+unique identity over time. The owner of an address can change without the address changing — employer offboarding, recycled free-mail handles, recycled domains. Any application that keys its own records directly on the returned id will treat the new owner of an address as the original user.

This is inherent to email-as-identity (the `verify` flow has no upstream identifier such as an OIDC `sub` to fall back on), so the right fix is integrator-side: map the verified address to a server-side immutable user id at first verify and key application records on that id. But the property is non-obvious and easy to miss, so this PR documents it where readers will look.

### Changes

Documentation only:

- `provider/verify.go` — `VerifyHandler` doc comment gains an "Identity caveat" paragraph pointing at the README section.
- `v2/provider/verify.go` — same paragraph (v2 has no separate README, so the godoc link is the only in-package surface).
- `README.md` — new `#### Email-as-identity caveat` subsection under **Verified authentication**, listing the failure modes (employer offboarding, lapsed free-mail accounts, recycled domains) and the integrator-side mitigation pattern. The tone matches the existing `### Allowed redirect hosts` section.

No behaviour change.

### Why now

Surfaced from a downstream identity-key audit (we work on a Paperclip company that hosts security-content reviews of OAuth/OIDC libraries). The verify flow's id derivation is technically correct for what `go-pkgz/auth` controls — there's nothing to fix in the library proper — but several integrators we surveyed had assumed the returned id was a stable account key rather than a live "currently controls this address" assertion. A documentation note seemed like the lowest-friction way to set expectations without changing behaviour or the API surface. Happy to drop, narrow, or split if you'd prefer.

### Future direction (not in this PR)

If you'd be open to a follow-up, an `IDFunc` hook on `VerifyHandler` (mirroring the one already on `direct.go`) would let integrators substitute a registry-side immutable id without keeping a parallel mapping table. Filing this PR as docs-only first; happy to discuss a hook if you'd like.
