### PR TITLE
fix(middleware): don't log admin password on basic-auth failure

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -235,7 +235,7 @@ func (a *Authenticator) basicAdminUser(r *http.Request) bool {
 
 	// using ConstantTimeCompare to avoid timing attack
 	if user != "admin" || subtle.ConstantTimeCompare([]byte(passwd), []byte(a.AdminPasswd)) != 1 {
-		a.Logf("[WARN] admin basic auth failed, user/passwd mismatch, %s:%s", user, passwd)
+		a.Logf("[WARN] admin basic auth failed for user %q", user)
 		return false
 	}
 

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -333,6 +334,23 @@ func TestAuthWithBasic(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, 401, resp.StatusCode, "admin with basic not allowed")
+}
+
+func TestBasicAdminUserDoesNotLogPassword(t *testing.T) {
+	const secret = "super-secret-attempted-passwd"
+	var buf strings.Builder
+	a := makeTestAuth(t)
+	a.L = logger.Func(func(format string, args ...interface{}) {
+		fmt.Fprintf(&buf, format, args...)
+	})
+
+	r, err := http.NewRequest("GET", "/auth", http.NoBody)
+	require.NoError(t, err)
+	r.SetBasicAuth("admin", secret)
+
+	assert.False(t, a.basicAdminUser(r), "wrong password must not authenticate")
+	assert.NotContains(t, buf.String(), secret, "attempted password must not appear in logs")
+	assert.Contains(t, buf.String(), "admin basic auth failed", "rejection should still be logged")
 }
 
 func TestAuthWithBasicChecker(t *testing.T) {

--- a/v2/middleware/auth.go
+++ b/v2/middleware/auth.go
@@ -243,7 +243,7 @@ func (a *Authenticator) basicAdminUser(r *http.Request) bool {
 
 	// using ConstantTimeCompare to avoid timing attack
 	if user != "admin" || subtle.ConstantTimeCompare([]byte(passwd), []byte(a.AdminPasswd)) != 1 {
-		a.Logf("[WARN] admin basic auth failed, user/passwd mismatch, %s:%s", user, passwd)
+		a.Logf("[WARN] admin basic auth failed for user %q", user)
 		return false
 	}
 

--- a/v2/middleware/auth_test.go
+++ b/v2/middleware/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -332,6 +333,23 @@ func TestAuthWithBasic(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, 401, resp.StatusCode, "admin with basic not allowed")
+}
+
+func TestBasicAdminUserDoesNotLogPassword(t *testing.T) {
+	const secret = "super-secret-attempted-passwd"
+	var buf strings.Builder
+	a := makeTestAuth(t)
+	a.L = logger.Func(func(format string, args ...interface{}) {
+		fmt.Fprintf(&buf, format, args...)
+	})
+
+	r, err := http.NewRequest("GET", "/auth", http.NoBody)
+	require.NoError(t, err)
+	r.SetBasicAuth("admin", secret)
+
+	assert.False(t, a.basicAdminUser(r), "wrong password must not authenticate")
+	assert.NotContains(t, buf.String(), secret, "attempted password must not appear in logs")
+	assert.Contains(t, buf.String(), "admin basic auth failed", "rejection should still be logged")
 }
 
 func TestAuthWithBasicChecker(t *testing.T) {


### PR DESCRIPTION
## Summary

Admin basic-auth rejection log line currently includes the attempted password verbatim:

```
[WARN] admin basic auth failed, user/passwd mismatch, admin:hunter2
```

A mistyped legitimate password (often one character off the real one) or a misrouted password-manager submission lands in plaintext logs that may be shipped to centralised logging, crash bundles, or third-party observability systems.

## Change

Drop the password from the log line, keep the username:

```
[WARN] admin basic auth failed for user "admin"
```

Same fix in v1 (`middleware/auth.go:238`) and v2 (`v2/middleware/auth.go:246`), single PR.

## Test

New `TestBasicAdminUserDoesNotLogPassword` in both modules — captures the logger output, calls `basicAdminUser` with a wrong password, asserts the password substring is not in the captured output and the rejection is still logged.

Confirmed RED→GREEN locally:
- before: assertion fails, log contains `admin:super-secret-attempted-passwd`
- after: assertion passes