### PR TITLE
chore: go fix ./...

### DIFF
--- a/avatar/avatar.go
+++ b/avatar/avatar.go
@@ -243,7 +243,7 @@ func GetGravatarURL(email string) (res string, err error) {
 }
 
 func retry(retries int, delay time.Duration, fn func() error) (err error) {
-	for i := 0; i < retries; i++ {
+	for range retries {
 		if err = fn(); err == nil {
 			return nil
 		}

--- a/logger/interface.go
+++ b/logger/interface.go
@@ -6,17 +6,17 @@ import "log"
 
 // L defined logger interface used everywhere in the package
 type L interface {
-	Logf(format string, args ...interface{})
+	Logf(format string, args ...any)
 }
 
 // Func type is an adapter to allow the use of ordinary functions as Logger.
-type Func func(format string, args ...interface{})
+type Func func(format string, args ...any)
 
 // Logf calls f(id)
-func (f Func) Logf(format string, args ...interface{}) { f(format, args...) }
+func (f Func) Logf(format string, args ...any) { f(format, args...) }
 
 // NoOp logger
-var NoOp = Func(func(string, ...interface{}) {})
+var NoOp = Func(func(string, ...any) {})
 
 // Std logger sends to std default logger directly
-var Std = Func(func(format string, args ...interface{}) { log.Printf(format, args...) })
+var Std = Func(func(format string, args ...any) { log.Printf(format, args...) })

--- a/logger/interface_test.go
+++ b/logger/interface_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestLogger(t *testing.T) {
 	buff := bytes.NewBufferString("")
-	lg := Func(func(format string, args ...interface{}) {
+	lg := Func(func(format string, args ...any) {
 		fmt.Fprintf(buff, format, args...)
 	})
 

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -28,8 +28,8 @@ type Authenticator struct {
 
 // RefreshCache defines interface storing and retrieving refreshed tokens
 type RefreshCache interface {
-	Get(key interface{}) (value interface{}, ok bool)
-	Set(key, value interface{})
+	Get(key any) (value any, ok bool)
+	Set(key, value any)
 }
 
 // TokenService defines interface accessing tokens
@@ -49,7 +49,7 @@ type BasicAuthFunc func(user, passwd string) (ok bool, userInfo token.User, err 
 var adminUser = token.User{
 	ID:   "admin",
 	Name: "admin",
-	Attributes: map[string]interface{}{
+	Attributes: map[string]any{
 		"admin": true,
 	},
 }

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -43,7 +43,7 @@ func TestAuthJWTCookie(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, token.User{Name: "name1", ID: "provider1_id1", Picture: "http://example.com/pic.png",
 			IP: "127.0.0.1", Email: "me@example.com", Audience: "test_sys",
-			Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, u)
+			Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, u)
 		w.WriteHeader(201)
 	}
 	mux.Handle("/auth", a.Auth(http.HandlerFunc(handler)))
@@ -178,7 +178,7 @@ func TestAuthJWTRefreshConcurrentWithCache(t *testing.T) {
 	var wg sync.WaitGroup
 	a.RefreshCache = newTestRefreshCache()
 	wg.Add(100)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		time.Sleep(1 * time.Millisecond) // TODO! not sure how testRefreshCache may have misses without this delay
 		go func() {
 			defer wg.Done()
@@ -449,7 +449,7 @@ func TestRBAC(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, token.User{Name: "name1", ID: "provider1_id1", Picture: "http://example.com/pic.png",
 			IP: "127.0.0.1", Email: "me@example.com", Audience: "test_sys",
-			Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"},
+			Attributes: map[string]any{"boola": true, "stra": "stra-val"},
 			Role:       "employee"}, u)
 		w.WriteHeader(201)
 	})
@@ -540,16 +540,16 @@ func makeTestAuth(_ *testing.T) Authenticator {
 }
 
 type testRefreshCache struct {
-	data map[interface{}]interface{}
+	data map[any]any
 	sync.RWMutex
 	hits, misses int32
 }
 
 func newTestRefreshCache() *testRefreshCache {
-	return &testRefreshCache{data: make(map[interface{}]interface{})}
+	return &testRefreshCache{data: make(map[any]any)}
 }
 
-func (c *testRefreshCache) Get(key interface{}) (value interface{}, ok bool) {
+func (c *testRefreshCache) Get(key any) (value any, ok bool) {
 	c.RLock()
 	defer c.RUnlock()
 	value, ok = c.data[key]
@@ -561,7 +561,7 @@ func (c *testRefreshCache) Get(key interface{}) (value interface{}, ok bool) {
 	return value, ok
 }
 
-func (c *testRefreshCache) Set(key, value interface{}) {
+func (c *testRefreshCache) Set(key, value any) {
 	c.Lock()
 	defer c.Unlock()
 	c.data[key] = value

--- a/provider/apple.go
+++ b/provider/apple.go
@@ -76,7 +76,7 @@ type AppleConfig struct {
 	ResponseMode string // changes method of receiving data in callback. Default value "form_post" (https://developer.apple.com/documentation/sign_in_with_apple/request_an_authorization_to_the_sign_in_with_apple_server?changes=_1_2#4066168)
 
 	scopes       []string         // for this package allow only username scope and UID in token claims. Apple service API provide only "email" and "name" scope values (https://developer.apple.com/documentation/sign_in_with_apple/clientconfigi/3230955-scope)
-	privateKey   interface{}      // private key from Apple obtained in developer account (the keys section). Required for create the Client Secret (https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3262048)
+	privateKey   any              // private key from Apple obtained in developer account (the keys section). Required for create the Client Secret (https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3262048)
 	publicKey    crypto.PublicKey // need for validate sign of token
 	clientSecret string           // is the JWT client secret will create after first call and then used until expired
 	jwkURL       string           // URL for fetch JWK Apple keys, need redefine for tests
@@ -228,7 +228,7 @@ func (ah *AppleHandler) initPrivateKey() error {
 }
 
 // tokenKeyFunc use for verify JWT sign, it receives the parsed token and should return the key for validating.
-func (ah *AppleHandler) tokenKeyFunc(jwtToken *jwt.Token) (interface{}, error) {
+func (ah *AppleHandler) tokenKeyFunc(jwtToken *jwt.Token) (any, error) {
 	if jwtToken == nil {
 		return nil, fmt.Errorf("failed to call token keyFunc, because token is nil")
 	}

--- a/provider/apple_pubkeys.go
+++ b/provider/apple_pubkeys.go
@@ -162,7 +162,7 @@ func (aks *appleKeySet) get(kid string) (keys *applePublicKey, err error) {
 }
 
 // keyFunc use for JWT verify with specific public key
-func (aks *appleKeySet) keyFunc(token *jwt.Token) (interface{}, error) {
+func (aks *appleKeySet) keyFunc(token *jwt.Token) (any, error) {
 
 	keyID, ok := token.Header["kid"].(string)
 	if !ok {

--- a/provider/apple_pubkeys_test.go
+++ b/provider/apple_pubkeys_test.go
@@ -131,7 +131,7 @@ func TestAppleKeySet_Get(t *testing.T) {
 
 func TestAppleKeySet_KeyFunc(t *testing.T) {
 
-	tokenHdr := map[string]interface{}{"kid": "86D88Kf"}
+	tokenHdr := map[string]any{"kid": "86D88Kf"}
 	validToken := jwt.Token{Header: tokenHdr}
 	testKeySet, err := parseAppleJWK([]byte(`{"keys":[{
 					  "kty": "RSA",

--- a/provider/apple_test.go
+++ b/provider/apple_test.go
@@ -593,7 +593,7 @@ func prepareAppleOauthTest(t *testing.T, loginPort, authPort int, testToken *str
 	}
 }
 
-func createTestResponseToken(privKey interface{}) (string, error) {
+func createTestResponseToken(privKey any) (string, error) {
 	claims := &jwt.MapClaims{
 		"iss":   "http://go.localhost.test",
 		"iat":   time.Now().Unix(),

--- a/provider/custom_server_test.go
+++ b/provider/custom_server_test.go
@@ -103,8 +103,7 @@ func TestCustomProvider(t *testing.T) {
 	router.Handle("/auth/customprov/", http.HandlerFunc(s.Handler))
 	ts := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", 8080), Handler: router} //nolint:gosec
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go prov.Run(ctx)
 	go ts.ListenAndServe()

--- a/provider/oauth1.go
+++ b/provider/oauth1.go
@@ -122,7 +122,7 @@ func (h Oauth1Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jData := map[string]interface{}{}
+	jData := map[string]any{}
 	if e := json.Unmarshal(data, &jData); e != nil {
 		rest.SendErrorJSON(w, r, h.L, http.StatusInternalServerError, err, "failed to unmarshal user info")
 		return

--- a/provider/oauth1_test.go
+++ b/provider/oauth1_test.go
@@ -74,7 +74,7 @@ func TestOauth1Login(t *testing.T) {
 	err = json.Unmarshal(body, &u)
 	assert.NoError(t, err)
 	assert.Equal(t, token.User{Name: "blah", ID: "mock_myuser2", Picture: "http://example.com/ava12345.png",
-		Attributes: map[string]interface{}{"admin": true}}, u)
+		Attributes: map[string]any{"admin": true}}, u)
 
 }
 

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -49,7 +49,7 @@ type Params struct {
 }
 
 // UserData is type for user information returned from oauth2 providers /info API method
-type UserData map[string]interface{}
+type UserData map[string]any
 
 // Value returns value for key or empty string if not found
 func (u UserData) Value(key string) string {
@@ -189,7 +189,7 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jData := map[string]interface{}{}
+	jData := map[string]any{}
 	if e := json.Unmarshal(data, &jData); e != nil {
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "failed to unmarshal user info")
 		return

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -85,7 +85,7 @@ func TestOauth2Login(t *testing.T) {
 	err = json.Unmarshal(body, &u)
 	assert.NoError(t, err)
 	assert.Equal(t, token.User{Name: "blah", ID: "mock_myuser2", Picture: "http://example.com/ava12345.png",
-		Attributes: map[string]interface{}{"admin": true}}, u)
+		Attributes: map[string]any{"admin": true}}, u)
 }
 
 func TestOauth2LoginBearerTokenHook(t *testing.T) {

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -34,7 +34,7 @@ func TestProviders_NewGoogle(t *testing.T) {
 			"email": "test@email.com"}
 		user := r.mapUser(udata, nil)
 		assert.Equal(t, token.User{Name: "test user", ID: "google_01b307acba4f54f55aafc33bb06bbbf6ca803e9a",
-			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]interface{}{"email": "test@email.com"}}, user, "got %+v", user)
+			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}}, user, "got %+v", user)
 	})
 }
 
@@ -65,7 +65,7 @@ func TestProviders_NewGithub(t *testing.T) {
 			"email": "test@email.com"}
 		user := r.mapUser(udata, nil)
 		assert.Equal(t, token.User{Name: "test user", ID: "github_e80b2d2608711cbb3312db7c4727a46fbad9601a",
-			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]interface{}{"email": "test@email.com"}}, user, "got %+v", user)
+			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}}, user, "got %+v", user)
 	})
 }
 
@@ -94,7 +94,7 @@ func TestProviders_NewFacebook(t *testing.T) {
 		udata := UserData{"id": "myid", "name": "test user", "email": "test@email.com"}
 		user := r.mapUser(udata, []byte(`{"picture": {"data": {"url": "http://demo.remark42.com/blah.png"} }}`))
 		assert.Equal(t, token.User{Name: "test user", ID: "facebook_6e34471f84557e1713012d64a7477c71bfdac631",
-			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]interface{}{"email": "test@email.com"}},
+			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}},
 			user, "got %+v", user)
 
 	})
@@ -202,7 +202,7 @@ func TestProviders_NewPatreon(t *testing.T) {
 	assert.Equal(
 		t,
 		token.User{Name: "Corgi The Dev", ID: "patreon_4e079d0555e5a2b460969c789d3ad968a795921f",
-			Picture: "https://c8.patreon.com/2/400/0000000", IP: "", Attributes: map[string]interface{}{"is_paid_sub": true}},
+			Picture: "https://c8.patreon.com/2/400/0000000", IP: "", Attributes: map[string]any{"is_paid_sub": true}},
 		user,
 		"got %+v",
 		user,

--- a/provider/telegram.go
+++ b/provider/telegram.go
@@ -449,7 +449,7 @@ func (tg *tgAPI) BotInfo(ctx context.Context) (*botInfo, error) {
 	return resp.Result, nil
 }
 
-func (tg *tgAPI) request(ctx context.Context, method string, data interface{}) error {
+func (tg *tgAPI) request(ctx context.Context, method string, data any) error {
 	return repeater.NewFixed(3, time.Millisecond*50).Do(ctx, func() error {
 		url := fmt.Sprintf("https://api.telegram.org/bot%s/%s", tg.token, method)
 

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -171,7 +171,7 @@ func (j *Service) Parse(tokenString string) (Claims, error) {
 		return Claims{}, fmt.Errorf("can't get secret: %w", err)
 	}
 
-	token, err := parser.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := parser.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -123,7 +123,7 @@ func TestJWT_Parse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
-		Email: "me@example.com", Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, claims.User)
+		Email: "me@example.com", Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, claims.User)
 
 	claims, err = j.Parse(testJwtExpired)
 	assert.NoError(t, err)
@@ -348,7 +348,7 @@ func TestJWT_GetFromHeader(t *testing.T) {
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
 		Email: "me@example.com", Audience: "test_sys",
-		Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, claims.User)
+		Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, claims.User)
 	assert.Equal(t, "remark42", claims.Issuer)
 
 	req = httptest.NewRequest("GET", "/", nil)
@@ -380,7 +380,7 @@ func TestJWT_GetFromQuery(t *testing.T) {
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
 		Email: "me@example.com", Audience: "test_sys",
-		Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, claims.User)
+		Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, claims.User)
 	assert.Equal(t, "remark42", claims.Issuer)
 
 	req = httptest.NewRequest("GET", "/blah?token="+testJwtExpired, nil)
@@ -435,7 +435,7 @@ func TestJWT_SetAndGetWithCookies(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
 		Email: "me@example.com", Audience: "test_sys",
-		Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, r.User)
+		Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, r.User)
 	assert.Equal(t, "remark42", claims.Issuer)
 	assert.Equal(t, true, claims.SessionOnly)
 	t.Log(resp.Cookies())
@@ -666,7 +666,7 @@ func TestParseWithAud(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
-		Email: "me@example.com", Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, claims.User)
+		Email: "me@example.com", Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, claims.User)
 
 	claims, err = j.Parse(testJwtValidAud)
 	assert.NoError(t, err)

--- a/token/user.go
+++ b/token/user.go
@@ -28,16 +28,16 @@ type User struct {
 	Audience string `json:"aud,omitempty"`
 
 	// set by client
-	IP         string                 `json:"ip,omitempty"`
-	Email      string                 `json:"email,omitempty"`
-	Attributes map[string]interface{} `json:"attrs,omitempty"`
-	Role       string                 `json:"role,omitempty"`
+	IP         string         `json:"ip,omitempty"`
+	Email      string         `json:"email,omitempty"`
+	Attributes map[string]any `json:"attrs,omitempty"`
+	Role       string         `json:"role,omitempty"`
 }
 
 // SetBoolAttr sets boolean attribute
 func (u *User) SetBoolAttr(key string, val bool) {
 	if u.Attributes == nil {
-		u.Attributes = map[string]interface{}{}
+		u.Attributes = map[string]any{}
 	}
 	u.Attributes[key] = val
 }
@@ -45,7 +45,7 @@ func (u *User) SetBoolAttr(key string, val bool) {
 // SetStrAttr sets string attribute
 func (u *User) SetStrAttr(key, val string) {
 	if u.Attributes == nil {
-		u.Attributes = map[string]interface{}{}
+		u.Attributes = map[string]any{}
 	}
 	u.Attributes[key] = val
 }
@@ -100,7 +100,7 @@ func (u *User) SliceAttr(key string) []string {
 // SetSliceAttr sets slice attribute for given key
 func (u *User) SetSliceAttr(key string, val []string) {
 	if u.Attributes == nil {
-		u.Attributes = map[string]interface{}{}
+		u.Attributes = map[string]any{}
 	}
 	u.Attributes[key] = val
 }

--- a/v2/avatar/avatar.go
+++ b/v2/avatar/avatar.go
@@ -243,7 +243,7 @@ func GetGravatarURL(email string) (res string, err error) {
 }
 
 func retry(retries int, delay time.Duration, fn func() error) (err error) {
-	for i := 0; i < retries; i++ {
+	for range retries {
 		if err = fn(); err == nil {
 			return nil
 		}

--- a/v2/logger/interface.go
+++ b/v2/logger/interface.go
@@ -6,17 +6,17 @@ import "log"
 
 // L defined logger interface used everywhere in the package
 type L interface {
-	Logf(format string, args ...interface{})
+	Logf(format string, args ...any)
 }
 
 // Func type is an adapter to allow the use of ordinary functions as Logger.
-type Func func(format string, args ...interface{})
+type Func func(format string, args ...any)
 
 // Logf calls f(id)
-func (f Func) Logf(format string, args ...interface{}) { f(format, args...) }
+func (f Func) Logf(format string, args ...any) { f(format, args...) }
 
 // NoOp logger
-var NoOp = Func(func(string, ...interface{}) {})
+var NoOp = Func(func(string, ...any) {})
 
 // Std logger sends to std default logger directly
-var Std = Func(func(format string, args ...interface{}) { log.Printf(format, args...) })
+var Std = Func(func(format string, args ...any) { log.Printf(format, args...) })

--- a/v2/logger/interface_test.go
+++ b/v2/logger/interface_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestLogger(t *testing.T) {
 	buff := bytes.NewBufferString("")
-	lg := Func(func(format string, args ...interface{}) {
+	lg := Func(func(format string, args ...any) {
 		fmt.Fprintf(buff, format, args...)
 	})
 

--- a/v2/middleware/auth.go
+++ b/v2/middleware/auth.go
@@ -57,7 +57,7 @@ type ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, statusCode in
 var adminUser = token.User{
 	ID:   "admin",
 	Name: "admin",
-	Attributes: map[string]interface{}{
+	Attributes: map[string]any{
 		"admin": true,
 	},
 }

--- a/v2/middleware/auth_test.go
+++ b/v2/middleware/auth_test.go
@@ -43,7 +43,7 @@ func TestAuthJWTCookie(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, token.User{Name: "name1", ID: "provider1_id1", Picture: "http://example.com/pic.png",
 			IP: "127.0.0.1", Email: "me@example.com", Audience: "test_sys",
-			Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, u)
+			Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, u)
 		w.WriteHeader(201)
 	}
 	mux.Handle("/auth", a.Auth(http.HandlerFunc(handler)))
@@ -177,7 +177,7 @@ func TestAuthJWTRefreshConcurrentWithCache(t *testing.T) {
 	var wg sync.WaitGroup
 	a.RefreshCache = newTestRefreshCache()
 	wg.Add(100)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		time.Sleep(1 * time.Millisecond) // TODO! not sure how testRefreshCache may have misses without this delay
 		go func() {
 			defer wg.Done()
@@ -448,7 +448,7 @@ func TestRBAC(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, token.User{Name: "name1", ID: "provider1_id1", Picture: "http://example.com/pic.png",
 			IP: "127.0.0.1", Email: "me@example.com", Audience: "test_sys",
-			Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"},
+			Attributes: map[string]any{"boola": true, "stra": "stra-val"},
 			Role:       "employee"}, u)
 		w.WriteHeader(201)
 	})

--- a/v2/provider/apple.go
+++ b/v2/provider/apple.go
@@ -76,7 +76,7 @@ type AppleConfig struct {
 	ResponseMode string // changes method of receiving data in callback. Default value "form_post" (https://developer.apple.com/documentation/sign_in_with_apple/request_an_authorization_to_the_sign_in_with_apple_server?changes=_1_2#4066168)
 
 	scopes       []string         // for this package allow only username scope and UID in token claims. Apple service API provide only "email" and "name" scope values (https://developer.apple.com/documentation/sign_in_with_apple/clientconfigi/3230955-scope)
-	privateKey   interface{}      // private key from Apple obtained in developer account (the keys section). Required for create the Client Secret (https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3262048)
+	privateKey   any              // private key from Apple obtained in developer account (the keys section). Required for create the Client Secret (https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3262048)
 	publicKey    crypto.PublicKey // need for validate sign of token
 	clientSecret string           // is the JWT client secret will create after first call and then used until expired
 	jwkURL       string           // URL for fetch JWK Apple keys, need redefine for tests
@@ -228,7 +228,7 @@ func (ah *AppleHandler) initPrivateKey() error {
 }
 
 // tokenKeyFunc use for verify JWT sign, it receives the parsed token and should return the key for validating.
-func (ah *AppleHandler) tokenKeyFunc(jwtToken *jwt.Token) (interface{}, error) {
+func (ah *AppleHandler) tokenKeyFunc(jwtToken *jwt.Token) (any, error) {
 	if jwtToken == nil {
 		return nil, fmt.Errorf("failed to call token keyFunc, because token is nil")
 	}

--- a/v2/provider/apple_pubkeys.go
+++ b/v2/provider/apple_pubkeys.go
@@ -162,7 +162,7 @@ func (aks *appleKeySet) get(kid string) (keys *applePublicKey, err error) {
 }
 
 // keyFunc use for JWT verify with specific public key
-func (aks *appleKeySet) keyFunc(token *jwt.Token) (interface{}, error) {
+func (aks *appleKeySet) keyFunc(token *jwt.Token) (any, error) {
 
 	keyID, ok := token.Header["kid"].(string)
 	if !ok {

--- a/v2/provider/apple_pubkeys_test.go
+++ b/v2/provider/apple_pubkeys_test.go
@@ -131,7 +131,7 @@ func TestAppleKeySet_Get(t *testing.T) {
 
 func TestAppleKeySet_KeyFunc(t *testing.T) {
 
-	tokenHdr := map[string]interface{}{"kid": "86D88Kf"}
+	tokenHdr := map[string]any{"kid": "86D88Kf"}
 	validToken := jwt.Token{Header: tokenHdr}
 	testKeySet, err := parseAppleJWK([]byte(`{"keys":[{
 					  "kty": "RSA",

--- a/v2/provider/apple_test.go
+++ b/v2/provider/apple_test.go
@@ -624,7 +624,7 @@ func prepareAppleOauthTest(t *testing.T, loginPort, authPort int, testToken *str
 	}
 }
 
-func createTestResponseToken(privKey interface{}) (string, error) {
+func createTestResponseToken(privKey any) (string, error) {
 	claims := &jwt.MapClaims{
 		"iss":   "http://go.localhost.test",
 		"iat":   time.Now().Unix(),

--- a/v2/provider/custom_server_test.go
+++ b/v2/provider/custom_server_test.go
@@ -103,8 +103,7 @@ func TestCustomProvider(t *testing.T) {
 	router.Handle("/auth/customprov/", http.HandlerFunc(s.Handler))
 	ts := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", 8080), Handler: router} //nolint:gosec
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go prov.Run(ctx)
 	go ts.ListenAndServe()

--- a/v2/provider/oauth1.go
+++ b/v2/provider/oauth1.go
@@ -122,7 +122,7 @@ func (h Oauth1Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jData := map[string]interface{}{}
+	jData := map[string]any{}
 	if e := json.Unmarshal(data, &jData); e != nil {
 		rest.SendErrorJSON(w, r, h.L, http.StatusInternalServerError, err, "failed to unmarshal user info")
 		return

--- a/v2/provider/oauth1_test.go
+++ b/v2/provider/oauth1_test.go
@@ -74,7 +74,7 @@ func TestOauth1Login(t *testing.T) {
 	err = json.Unmarshal(body, &u)
 	assert.NoError(t, err)
 	assert.Equal(t, token.User{Name: "blah", ID: "mock_myuser2", Picture: "http://example.com/ava12345.png",
-		Attributes: map[string]interface{}{"admin": true}}, u)
+		Attributes: map[string]any{"admin": true}}, u)
 
 }
 

--- a/v2/provider/oauth2.go
+++ b/v2/provider/oauth2.go
@@ -57,7 +57,7 @@ type Params struct {
 }
 
 // UserData is type for user information returned from oauth2 providers /info API method
-type UserData map[string]interface{}
+type UserData map[string]any
 
 // Value returns value for key or empty string if not found
 func (u UserData) Value(key string) string {
@@ -197,7 +197,7 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jData := map[string]interface{}{}
+	jData := map[string]any{}
 	if e := json.Unmarshal(data, &jData); e != nil {
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "failed to unmarshal user info")
 		return

--- a/v2/provider/providers_test.go
+++ b/v2/provider/providers_test.go
@@ -34,7 +34,7 @@ func TestProviders_NewGoogle(t *testing.T) {
 			"email": "test@email.com"}
 		user := r.mapUser(udata, nil)
 		assert.Equal(t, token.User{Name: "test user", ID: "google_01b307acba4f54f55aafc33bb06bbbf6ca803e9a",
-			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]interface{}{"email": "test@email.com"}}, user, "got %+v", user)
+			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}}, user, "got %+v", user)
 	})
 }
 
@@ -65,7 +65,7 @@ func TestProviders_NewGithub(t *testing.T) {
 			"email": "test@email.com"}
 		user := r.mapUser(udata, nil)
 		assert.Equal(t, token.User{Name: "test user", ID: "github_e80b2d2608711cbb3312db7c4727a46fbad9601a",
-			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]interface{}{"email": "test@email.com"}}, user, "got %+v", user)
+			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}}, user, "got %+v", user)
 	})
 }
 
@@ -94,7 +94,7 @@ func TestProviders_NewFacebook(t *testing.T) {
 		udata := UserData{"id": "myid", "name": "test user", "email": "test@email.com"}
 		user := r.mapUser(udata, []byte(`{"picture": {"data": {"url": "http://demo.remark42.com/blah.png"} }}`))
 		assert.Equal(t, token.User{Name: "test user", ID: "facebook_6e34471f84557e1713012d64a7477c71bfdac631",
-			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]interface{}{"email": "test@email.com"}},
+			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}},
 			user, "got %+v", user)
 
 	})
@@ -202,7 +202,7 @@ func TestProviders_NewPatreon(t *testing.T) {
 	assert.Equal(
 		t,
 		token.User{Name: "Corgi The Dev", ID: "patreon_4e079d0555e5a2b460969c789d3ad968a795921f",
-			Picture: "https://c8.patreon.com/2/400/0000000", IP: "", Attributes: map[string]interface{}{"is_paid_sub": true}},
+			Picture: "https://c8.patreon.com/2/400/0000000", IP: "", Attributes: map[string]any{"is_paid_sub": true}},
 		user,
 		"got %+v",
 		user,

--- a/v2/provider/telegram.go
+++ b/v2/provider/telegram.go
@@ -449,7 +449,7 @@ func (tg *tgAPI) BotInfo(ctx context.Context) (*botInfo, error) {
 	return resp.Result, nil
 }
 
-func (tg *tgAPI) request(ctx context.Context, method string, data interface{}) error {
+func (tg *tgAPI) request(ctx context.Context, method string, data any) error {
 	return repeater.NewFixed(3, time.Millisecond*50).Do(ctx, func() error {
 		url := fmt.Sprintf("https://api.telegram.org/bot%s/%s", tg.token, method)
 

--- a/v2/token/jwt_test.go
+++ b/v2/token/jwt_test.go
@@ -123,7 +123,7 @@ func TestJWT_Parse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
-		Email: "me@example.com", Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, claims.User)
+		Email: "me@example.com", Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, claims.User)
 
 	claims, err = j.Parse(testJwtExpired)
 	assert.NoError(t, err)
@@ -348,7 +348,7 @@ func TestJWT_GetFromHeader(t *testing.T) {
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
 		Email: "me@example.com", Audience: "test_sys",
-		Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, claims.User)
+		Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, claims.User)
 	assert.Equal(t, "remark42", claims.Issuer)
 
 	req = httptest.NewRequest("GET", "/", nil)
@@ -380,7 +380,7 @@ func TestJWT_GetFromQuery(t *testing.T) {
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
 		Email: "me@example.com", Audience: "test_sys",
-		Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, claims.User)
+		Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, claims.User)
 	assert.Equal(t, "remark42", claims.Issuer)
 
 	req = httptest.NewRequest("GET", "/blah?token="+testJwtExpired, nil)
@@ -435,7 +435,7 @@ func TestJWT_SetAndGetWithCookies(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
 		Email: "me@example.com", Audience: "test_sys",
-		Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, r.User)
+		Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, r.User)
 	assert.Equal(t, "remark42", claims.Issuer)
 	assert.Equal(t, true, claims.SessionOnly)
 	t.Log(resp.Cookies())
@@ -666,7 +666,7 @@ func TestParseWithAud(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, j.IsExpired(claims))
 	assert.Equal(t, &User{Name: "name1", ID: "id1", Picture: "http://example.com/pic.png", IP: "127.0.0.1",
-		Email: "me@example.com", Attributes: map[string]interface{}{"boola": true, "stra": "stra-val"}}, claims.User)
+		Email: "me@example.com", Attributes: map[string]any{"boola": true, "stra": "stra-val"}}, claims.User)
 
 	claims, err = j.Parse(testJwtValidAud)
 	assert.NoError(t, err)

--- a/v2/token/user.go
+++ b/v2/token/user.go
@@ -28,16 +28,16 @@ type User struct {
 	Audience string `json:"aud,omitempty"`
 
 	// set by client
-	IP         string                 `json:"ip,omitempty"`
-	Email      string                 `json:"email,omitempty"`
-	Attributes map[string]interface{} `json:"attrs,omitempty"`
-	Role       string                 `json:"role,omitempty"`
+	IP         string         `json:"ip,omitempty"`
+	Email      string         `json:"email,omitempty"`
+	Attributes map[string]any `json:"attrs,omitempty"`
+	Role       string         `json:"role,omitempty"`
 }
 
 // SetBoolAttr sets boolean attribute
 func (u *User) SetBoolAttr(key string, val bool) {
 	if u.Attributes == nil {
-		u.Attributes = map[string]interface{}{}
+		u.Attributes = map[string]any{}
 	}
 	u.Attributes[key] = val
 }
@@ -45,7 +45,7 @@ func (u *User) SetBoolAttr(key string, val bool) {
 // SetStrAttr sets string attribute
 func (u *User) SetStrAttr(key, val string) {
 	if u.Attributes == nil {
-		u.Attributes = map[string]interface{}{}
+		u.Attributes = map[string]any{}
 	}
 	u.Attributes[key] = val
 }
@@ -100,7 +100,7 @@ func (u *User) SliceAttr(key string) []string {
 // SetSliceAttr sets slice attribute for given key
 func (u *User) SetSliceAttr(key string, val []string) {
 	if u.Attributes == nil {
-		u.Attributes = map[string]interface{}{}
+		u.Attributes = map[string]any{}
 	}
 	u.Attributes[key] = val
 }


### PR DESCRIPTION
## Summary

Apply Go modernization fixes from `go fix ./...` across both v1 and v2.

Mainly `interface{}` → `any` (the Go 1.18+ alias) plus small idiomatic updates the tool emits. Found while preparing PRs #279/#280/#281/#282 — kept separate so those security PRs stay focused.

## Change

- 36 files updated, ~84 insertions / ~86 deletions
- No behaviour changes; pure hygiene
- Go 1.25+ as required by `CLAUDE.md` and `go.mod`

## Test

`go test -race ./...` green in both v1 and v2.