### PR TITLE
fix(apple): redact tokens from exchange-response debug log

### DIFF
--- a/provider/apple.go
+++ b/provider/apple.go
@@ -331,7 +331,7 @@ func (ah AppleHandler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "exchange failed")
 		return
 	}
-	ah.Logf("[DEBUG] response data %+v", resp)
+	ah.Logf("[DEBUG] apple exchange response: %s", appleVerificationResponseLogSummary(resp))
 	if resp.Error != "" {
 		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, nil, fmt.Sprintf("fetch IDtoken response error: %s", resp.Error))
 		return
@@ -543,4 +543,23 @@ func (ah AppleHandler) makeRedirURL(path string) string {
 	newPath := strings.Join(elems[:len(elems)-1], "/")
 
 	return strings.TrimRight(ah.URL, "/") + strings.TrimSuffix(newPath, "/") + urlCallbackSuffix
+}
+
+// appleVerificationResponseLogSummary formats appleVerificationResponse for safe
+// logging. The struct's AccessToken, RefreshToken and IDToken fields are
+// credentials and must never appear verbatim in logs that may be shipped to
+// centralized logging or third-party observability systems; this helper logs
+// only their presence (present|missing), the non-secret token type and
+// expiry, plus any provider-side error string.
+func appleVerificationResponseLogSummary(r appleVerificationResponse) string {
+	return fmt.Sprintf("type=%s expires_in=%d access_token=%s refresh_token=%s id_token=%s error=%q",
+		r.TokenType, r.ExpiresIn,
+		presence(r.AccessToken), presence(r.RefreshToken), presence(r.IDToken), r.Error)
+}
+
+func presence(s string) string {
+	if s == "" {
+		return "missing"
+	}
+	return "present"
 }

--- a/provider/apple_test.go
+++ b/provider/apple_test.go
@@ -232,6 +232,26 @@ func TestPrepareLoginURLWithCustomResponseMode(t *testing.T) {
 	assert.Equal(t, q.Get("client_id"), ah.conf.ClientID)
 }
 
+func TestAppleVerificationResponseLogSummary(t *testing.T) {
+	resp := appleVerificationResponse{
+		AccessToken:  "secret-access-token-XYZ",
+		TokenType:    "bearer",
+		ExpiresIn:    3600,
+		RefreshToken: "secret-refresh-token-XYZ",
+		IDToken:      "secret-id-token-eyJhbGc",
+	}
+	summary := appleVerificationResponseLogSummary(resp)
+	assert.NotContains(t, summary, "secret-access-token-XYZ", "access token must not appear in log summary")
+	assert.NotContains(t, summary, "secret-refresh-token-XYZ", "refresh token must not appear in log summary")
+	assert.NotContains(t, summary, "secret-id-token-eyJhbGc", "id token must not appear in log summary")
+	assert.Contains(t, summary, "bearer", "token type is safe to log")
+	assert.Contains(t, summary, "3600", "expiry seconds is safe to log")
+	assert.Contains(t, summary, "id_token=present", "presence of id token should be loggable")
+
+	missing := appleVerificationResponseLogSummary(appleVerificationResponse{TokenType: "bearer"})
+	assert.Contains(t, missing, "id_token=missing")
+}
+
 func TestThrowsWhenNotEmptyScopeAndWrongResponseMode(t *testing.T) {
 	ah, err := prepareAppleHandlerTest("query", []string{"email"})
 	assert.NoError(t, err)

--- a/v2/provider/apple.go
+++ b/v2/provider/apple.go
@@ -331,7 +331,7 @@ func (ah AppleHandler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, err, "exchange failed")
 		return
 	}
-	ah.Logf("[DEBUG] response data %+v", resp)
+	ah.Logf("[DEBUG] apple exchange response: %s", appleVerificationResponseLogSummary(resp))
 	if resp.Error != "" {
 		rest.SendErrorJSON(w, r, ah.L, http.StatusInternalServerError, nil, fmt.Sprintf("fetch IDtoken response error: %s", resp.Error))
 		return
@@ -548,4 +548,23 @@ func (ah AppleHandler) makeRedirURL(path string) string {
 	newPath := strings.Join(elems[:len(elems)-1], "/")
 
 	return strings.TrimRight(ah.URL, "/") + strings.TrimSuffix(newPath, "/") + urlCallbackSuffix
+}
+
+// appleVerificationResponseLogSummary formats appleVerificationResponse for safe
+// logging. The struct's AccessToken, RefreshToken and IDToken fields are
+// credentials and must never appear verbatim in logs that may be shipped to
+// centralized logging or third-party observability systems; this helper logs
+// only their presence (present|missing), the non-secret token type and
+// expiry, plus any provider-side error string.
+func appleVerificationResponseLogSummary(r appleVerificationResponse) string {
+	return fmt.Sprintf("type=%s expires_in=%d access_token=%s refresh_token=%s id_token=%s error=%q",
+		r.TokenType, r.ExpiresIn,
+		presence(r.AccessToken), presence(r.RefreshToken), presence(r.IDToken), r.Error)
+}
+
+func presence(s string) string {
+	if s == "" {
+		return "missing"
+	}
+	return "present"
 }

--- a/v2/provider/apple_test.go
+++ b/v2/provider/apple_test.go
@@ -232,6 +232,26 @@ func TestPrepareLoginURLWithCustomResponseMode(t *testing.T) {
 	assert.Equal(t, q.Get("client_id"), ah.conf.ClientID)
 }
 
+func TestAppleVerificationResponseLogSummary(t *testing.T) {
+	resp := appleVerificationResponse{
+		AccessToken:  "secret-access-token-XYZ",
+		TokenType:    "bearer",
+		ExpiresIn:    3600,
+		RefreshToken: "secret-refresh-token-XYZ",
+		IDToken:      "secret-id-token-eyJhbGc",
+	}
+	summary := appleVerificationResponseLogSummary(resp)
+	assert.NotContains(t, summary, "secret-access-token-XYZ", "access token must not appear in log summary")
+	assert.NotContains(t, summary, "secret-refresh-token-XYZ", "refresh token must not appear in log summary")
+	assert.NotContains(t, summary, "secret-id-token-eyJhbGc", "id token must not appear in log summary")
+	assert.Contains(t, summary, "bearer", "token type is safe to log")
+	assert.Contains(t, summary, "3600", "expiry seconds is safe to log")
+	assert.Contains(t, summary, "id_token=present", "presence of id token should be loggable")
+
+	missing := appleVerificationResponseLogSummary(appleVerificationResponse{TokenType: "bearer"})
+	assert.Contains(t, missing, "id_token=missing")
+}
+
 func TestThrowsWhenNotEmptyScopeAndWrongResponseMode(t *testing.T) {
 	ah, err := prepareAppleHandlerTest("query", []string{"email"})
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary

The Apple handler logged the full `appleVerificationResponse` struct on a `[DEBUG]` line:

```
[DEBUG] response data {AccessToken:M... TokenType:bearer ExpiresIn:3600
    RefreshToken:Iw... IDToken:eyJ...}
```

`AccessToken`, `RefreshToken` and `IDToken` are bearer credentials. With DEBUG-level logging enabled (default in many staging setups) these landed in stdout, file logs, centralized logging, crash bundles, and any third-party observability stack — anywhere log access doesn't imply auth-server-process compromise.

## Change

Replace the raw `%+v` dump with `appleVerificationResponseLogSummary`, which logs only the non-secret fields plus presence indicators (`present|missing`) for each token. Operators can still tell whether a response carried each token; the value never leaks.

```
[DEBUG] apple exchange response: type=bearer expires_in=3600
    access_token=present refresh_token=present id_token=present error=""
```

Same redaction in v1 (`provider/apple.go:334`) and v2 (`v2/provider/apple.go:334`), single PR.

## Test

`TestAppleVerificationResponseLogSummary` asserts the helper omits the three secret values verbatim and reports presence/missing correctly. Added in both modules. Full `go test -race ./...` green; `golangci-lint run --new-from-rev=master` 0 issues.