### PR TITLE
fix(sender/email): don't log email body, log size instead

### DIFF
--- a/provider/sender/email.go
+++ b/provider/sender/email.go
@@ -79,9 +79,13 @@ func NewEmailClient(emailParams EmailParams, l logger.L) *Email {
 	return &Email{EmailParams: emailParams, L: l, sender: sender}
 }
 
-// Send email with given text
+// Send email with given text. The body is not logged: confirmation emails
+// sent by the verify provider contain a one-shot magic-link token, and any
+// party with log access could redeem it before the user does. Logging only
+// the recipient and body length keeps the line useful for operators
+// without leaking the credential.
 func (e *Email) Send(to, text string) error {
-	e.Logf("[DEBUG] send %q to %s", text, to)
+	e.Logf("[DEBUG] send %d-byte message to %s", len(text), to)
 	return e.sender.Send(text, email.Params{
 		From:    e.From,
 		To:      []string{to},

--- a/provider/sender/email_test.go
+++ b/provider/sender/email_test.go
@@ -1,7 +1,9 @@
 package sender
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,6 +54,23 @@ func TestEmail_New(t *testing.T) {
 	}
 	e := NewEmailClient(p, logger.Std)
 	assert.Equal(t, p, e.EmailParams)
+}
+
+func TestEmail_SendDoesNotLogBody(t *testing.T) {
+	const secretBody = "Confirmation token: super-secret-magic-link-XYZ"
+	var buf strings.Builder
+	capturing := logger.Func(func(format string, args ...interface{}) {
+		fmt.Fprintf(&buf, format, args...)
+	})
+	p := EmailParams{Host: "127.0.0.2", Port: 25, From: "from@example.com",
+		Subject: "subj", ContentType: "text/html", TimeOut: time.Millisecond * 100}
+	e := NewEmailClient(p, capturing)
+	_ = e.Send("victim@example.com", secretBody) // expected to fail (no smtp server) — we only assert the log
+
+	logged := buf.String()
+	assert.NotContains(t, logged, secretBody, "email body must not appear in logs")
+	assert.NotContains(t, logged, "super-secret-magic-link-XYZ", "any substring of the body must not appear in logs")
+	assert.Contains(t, logged, "victim@example.com", "recipient is safe to log")
 }
 
 func TestEmail_SendFailed(t *testing.T) {

--- a/v2/provider/sender/email.go
+++ b/v2/provider/sender/email.go
@@ -79,9 +79,13 @@ func NewEmailClient(emailParams EmailParams, l logger.L) *Email {
 	return &Email{EmailParams: emailParams, L: l, sender: sender}
 }
 
-// Send email with given text
+// Send email with given text. The body is not logged: confirmation emails
+// sent by the verify provider contain a one-shot magic-link token, and any
+// party with log access could redeem it before the user does. Logging only
+// the recipient and body length keeps the line useful for operators
+// without leaking the credential.
 func (e *Email) Send(to, text string) error {
-	e.Logf("[DEBUG] send %q to %s", text, to)
+	e.Logf("[DEBUG] send %d-byte message to %s", len(text), to)
 	return e.sender.Send(text, email.Params{
 		From:    e.From,
 		To:      []string{to},

--- a/v2/provider/sender/email_test.go
+++ b/v2/provider/sender/email_test.go
@@ -1,7 +1,9 @@
 package sender
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,6 +54,23 @@ func TestEmail_New(t *testing.T) {
 	}
 	e := NewEmailClient(p, logger.Std)
 	assert.Equal(t, p, e.EmailParams)
+}
+
+func TestEmail_SendDoesNotLogBody(t *testing.T) {
+	const secretBody = "Confirmation token: super-secret-magic-link-XYZ"
+	var buf strings.Builder
+	capturing := logger.Func(func(format string, args ...interface{}) {
+		fmt.Fprintf(&buf, format, args...)
+	})
+	p := EmailParams{Host: "127.0.0.2", Port: 25, From: "from@example.com",
+		Subject: "subj", ContentType: "text/html", TimeOut: time.Millisecond * 100}
+	e := NewEmailClient(p, capturing)
+	_ = e.Send("victim@example.com", secretBody)
+
+	logged := buf.String()
+	assert.NotContains(t, logged, secretBody, "email body must not appear in logs")
+	assert.NotContains(t, logged, "super-secret-magic-link-XYZ", "any substring of the body must not appear in logs")
+	assert.Contains(t, logged, "victim@example.com", "recipient is safe to log")
 }
 
 func TestEmail_SendFailed(t *testing.T) {


### PR DESCRIPTION
## Summary

The verify provider sends one-shot magic-link tokens via email. The Email sender's debug log dumped the full body verbatim:

```
[DEBUG] send "Confirmation token: <jwt>" to victim@example.com
```

Anyone with log access (centralized logging, crash bundles, support tools, mail-gateway observability) could redeem that token within its TTL — independently of the legitimate recipient. PR #281 (verify replay) limits reuse to one consumption, but the log reader can still race the user for that one consumption. This PR closes the leak at the source.

## Change

Log the recipient and body length only:

```
[DEBUG] send 142-byte message to victim@example.com
```

Same redaction in v1 (`provider/sender/email.go:84`) and v2 (`v2/provider/sender/email.go:84`), single PR.

## Test

`TestEmail_SendDoesNotLogBody` captures logger output, sends a known-secret body to a non-existent SMTP host (Send fails fast — that's fine, we only assert on the log line), and verifies:
- the body substring is absent from the log
- the recipient address is present (operators still need this for ops)

Added in both modules. Full `go test -race ./...` green; `golangci-lint run --new-from-rev=master` 0 issues.