### PR TITLE
fix(provider): bind dev oauth and custom-server to localhost by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Once the policy is on:
 
 ### Dev provider
 
-Working with oauth2 providers can be a pain, especially during development phase. A special, development-only provider `dev` can make it less painful. This one can be registered directly, i.e. `service.AddProvider("dev", "", "")` or `service.AddDevProvider(port)` and should be activated like this:
+Working with oauth2 providers can be a pain, especially during development phase. A special, development-only provider `dev` can make it less painful. This one can be registered directly, i.e. `service.AddProvider("dev", "", "")` or `service.AddDevProvider(host, port)` and should be activated like this:
 
 ```go
 	// runs dev oauth2 server on :8084 by default
@@ -563,6 +563,31 @@ Working with oauth2 providers can be a pain, especially during development phase
 It will run fake aouth2 "server" on port :8084 and user could login with any user name. See [example](https://github.com/go-pkgz/auth/blob/master/_example/main.go) for more details.
 
 _Warning: this is not the real oauth2 server but just a small fake thing for development and testing only. Don't use `dev` provider with any production code._
+
+#### Listen address
+
+The dev OAuth server and the embedded `CustomServer` helper bind to **`127.0.0.1` by default** so the dev login UI is not silently exposed to the LAN, Docker network siblings, kubernetes pods on the same node, etc.
+
+##### Dev provider
+
+The dev provider has a separate `Host` field for the listen address; the OAuth callback URL is taken from `Opts.URL` and is independent. To bind to all interfaces (e.g. when the auth process runs inside a container and needs to be reachable from the host) pass `Host` explicitly:
+
+```go
+// dev provider -- listen on all interfaces, callback URL stays whatever you set in Opts.URL
+service.AddDevProvider("0.0.0.0", 8084)
+```
+
+##### CustomServer
+
+`CustomServer` is the awkward case: `CustomServerOpt.URL` is used **both** as the bind source **and** as the advertised OAuth endpoint (it appears verbatim in `AuthURL`, `TokenURL` and `InfoURL` returned to clients). There is no separate bind setting today, so `URL: "http://0.0.0.0:9096"` is **only** appropriate when every consumer of those advertised endpoints is fine with `0.0.0.0` as a hostname -- which is essentially never the case in practice.
+
+Recommended approaches:
+
+* **Single host, no proxy** -- leave `URL: "http://localhost:9096"` (or your real hostname). The default loopback bind matches the advertised host and everything works.
+* **Behind a reverse proxy (typical Docker/kubernetes pattern)** -- terminate at the proxy on the public hostname and let the auth process talk to the proxy over a docker network or unix socket. Set `URL` to the public-facing value the proxy serves and bind the auth process to a network the proxy can reach (e.g. a docker network, or `0.0.0.0` if the proxy is on a different host and the network is otherwise restricted). The advertised URL stays correct because that is what `Opts.URL` says.
+* **Direct LAN exposure with a sensible advertised URL** -- set `URL` to a real hostname or LAN IP that resolves on every consumer (e.g. `http://oauth.lan.example:9096`); the bind extracts the host and listens there. Avoid embedding `0.0.0.0` in `URL` unless you have already accepted the consequence that clients will see `0.0.0.0` in the advertised metadata.
+
+A future change is likely to add a separate bind option (`CustomServerOpt.BindAddr` or similar) so the bind and the advertised URL can diverge cleanly; until then, the bind follows `URL`.
 
 By default, Dev provider doesn't return `email` claim from `/user` endpoint, to match behaviour of other providers which only request minimal scopes.
 However sometimes it is useful to have `email` included into user info. This can be done by configuring `devAuthServer.GetEmailFn` function:

--- a/provider/custom_server.go
+++ b/provider/custom_server.go
@@ -79,17 +79,25 @@ func (c *CustomServer) Run(ctx context.Context) {
 	u, err := url.Parse(c.URL)
 	if err != nil {
 		c.Logf("[ERROR] failed to parse service base URL=%s", c.URL)
+		c.lock.Unlock()
 		return
 	}
 
-	_, port, err := net.SplitHostPort(u.Host)
+	host, port, err := net.SplitHostPort(u.Host)
 	if err != nil {
 		c.Logf("[ERROR] failed to get port from URL=%s", c.URL)
+		c.lock.Unlock()
 		return
+	}
+	// hostname from URL is honored; only an explicit non-loopback host
+	// (e.g. "0.0.0.0" baked into c.URL) binds beyond loopback. Empty/
+	// "localhost" falls through to localBindAddr's 127.0.0.1 default.
+	if host == "localhost" {
+		host = ""
 	}
 
 	c.httpServer = &http.Server{
-		Addr:              fmt.Sprintf(":%s", port),
+		Addr:              localBindAddr(host, port),
 		ReadHeaderTimeout: 5 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {

--- a/provider/custom_server_test.go
+++ b/provider/custom_server_test.go
@@ -26,6 +26,38 @@ import (
 	"github.com/go-pkgz/auth/token"
 )
 
+// TestCustomServer_Run_BadURLDoesNotDeadlockShutdown drives the early-return
+// branches of CustomServer.Run (URL parse failure and host:port split failure)
+// and asserts that Shutdown() can still acquire the mutex afterwards. Before
+// the fix, those branches returned with c.lock held; Shutdown would then
+// block on the inherited mutex and this test would time out.
+func TestCustomServer_Run_BadURLDoesNotDeadlockShutdown(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{name: "unparseable URL", url: "://broken"},
+		{name: "URL without port", url: "http://localhost"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &CustomServer{L: logger.NoOp, URL: tc.url}
+			c.Run(context.Background())
+
+			done := make(chan struct{})
+			go func() {
+				c.Shutdown()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Shutdown blocked -- Run left c.lock held on error path")
+			}
+		})
+	}
+}
+
 func TestCustomProvider(t *testing.T) {
 	srv := initGoauth2Srv(t)
 

--- a/provider/dev_provider.go
+++ b/provider/dev_provider.go
@@ -57,7 +57,7 @@ func (d *DevAuthServer) Run(ctx context.Context) { // nolint (gocyclo)
 	}
 
 	d.httpServer = &http.Server{
-		Addr:              fmt.Sprintf(":%d", d.Provider.Port),
+		Addr:              localBindAddr(d.Provider.Host, fmt.Sprintf("%d", d.Provider.Port)),
 		ReadHeaderTimeout: 5 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			d.Logf("[DEBUG] dev oauth request %s %s %+v", r.Method, r.URL, r.Header)

--- a/provider/service.go
+++ b/provider/service.go
@@ -4,12 +4,27 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
 	"github.com/go-pkgz/auth/avatar"
 	"github.com/go-pkgz/auth/token"
 )
+
+// localBindAddr returns the listen address for the dev oauth and custom-server
+// helpers. Both servers are intended for local development and embedded
+// flows; the historical default ":port" listened on every interface, which
+// silently exposed the dev OAuth UI to anyone on the LAN. Default the bind
+// to 127.0.0.1; callers that explicitly want a non-loopback bind can pass
+// a hostname (e.g. "0.0.0.0" or a specific IP) via Provider.Host (dev) or
+// the URL host (custom-server).
+func localBindAddr(host, port string) string {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, port)
+}
 
 const (
 	urlLoginSuffix    = "/login"

--- a/provider/service_test.go
+++ b/provider/service_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,6 +57,35 @@ func TestRandToken(t *testing.T) {
 	assert.NotEqual(t, "", s2)
 	assert.NotEqual(t, s2, s1)
 	t.Log(s2)
+}
+
+func TestLocalBindAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port string
+		want string
+	}{
+		{name: "empty host defaults to 127.0.0.1 (the security-relevant default)", host: "", port: "8080", want: "127.0.0.1:8080"},
+		{name: "explicit 127.0.0.1 honored", host: "127.0.0.1", port: "8080", want: "127.0.0.1:8080"},
+		{name: "explicit non-loopback honored (opt-in to LAN exposure)", host: "192.168.1.10", port: "8080", want: "192.168.1.10:8080"},
+		{name: "explicit 0.0.0.0 honored (caller is asking for it)", host: "0.0.0.0", port: "8080", want: "0.0.0.0:8080"},
+		{name: "ipv6 hostname is bracketed by net.JoinHostPort", host: "::1", port: "8080", want: "[::1]:8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, localBindAddr(tt.host, tt.port))
+		})
+	}
+}
+
+func TestLocalBindAddr_DefaultIsNotAllInterfaces(t *testing.T) {
+	// regression: the historical bind ":port" was a security smell —
+	// listened on every interface, including LAN. The default for the
+	// dev / custom helpers must never produce that string.
+	addr := localBindAddr("", "12345")
+	assert.NotEqual(t, ":12345", addr, "default bind must not be all-interfaces")
+	assert.False(t, strings.HasPrefix(addr, ":"), "default bind must include a hostname, not the bare-port shorthand")
 }
 
 func TestSetAvatar(t *testing.T) {

--- a/v2/provider/custom_server.go
+++ b/v2/provider/custom_server.go
@@ -79,17 +79,25 @@ func (c *CustomServer) Run(ctx context.Context) {
 	u, err := url.Parse(c.URL)
 	if err != nil {
 		c.Logf("[ERROR] failed to parse service base URL=%s", c.URL)
+		c.lock.Unlock()
 		return
 	}
 
-	_, port, err := net.SplitHostPort(u.Host)
+	host, port, err := net.SplitHostPort(u.Host)
 	if err != nil {
 		c.Logf("[ERROR] failed to get port from URL=%s", c.URL)
+		c.lock.Unlock()
 		return
+	}
+	// hostname from URL is honored; only an explicit non-loopback host
+	// (e.g. "0.0.0.0" baked into c.URL) binds beyond loopback. Empty/
+	// "localhost" falls through to localBindAddr's 127.0.0.1 default.
+	if host == "localhost" {
+		host = ""
 	}
 
 	c.httpServer = &http.Server{
-		Addr:              fmt.Sprintf(":%s", port),
+		Addr:              localBindAddr(host, port),
 		ReadHeaderTimeout: 5 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {

--- a/v2/provider/custom_server_test.go
+++ b/v2/provider/custom_server_test.go
@@ -26,6 +26,38 @@ import (
 	"github.com/go-pkgz/auth/v2/token"
 )
 
+// TestCustomServer_Run_BadURLDoesNotDeadlockShutdown drives the early-return
+// branches of CustomServer.Run (URL parse failure and host:port split failure)
+// and asserts that Shutdown() can still acquire the mutex afterwards. Before
+// the fix, those branches returned with c.lock held; Shutdown would then
+// block on the inherited mutex and this test would time out.
+func TestCustomServer_Run_BadURLDoesNotDeadlockShutdown(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{name: "unparseable URL", url: "://broken"},
+		{name: "URL without port", url: "http://localhost"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &CustomServer{L: logger.NoOp, URL: tc.url}
+			c.Run(context.Background())
+
+			done := make(chan struct{})
+			go func() {
+				c.Shutdown()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Shutdown blocked -- Run left c.lock held on error path")
+			}
+		})
+	}
+}
+
 func TestCustomProvider(t *testing.T) {
 	srv := initGoauth2Srv(t)
 

--- a/v2/provider/dev_provider.go
+++ b/v2/provider/dev_provider.go
@@ -57,7 +57,7 @@ func (d *DevAuthServer) Run(ctx context.Context) { // nolint (gocyclo)
 	}
 
 	d.httpServer = &http.Server{
-		Addr:              fmt.Sprintf(":%d", d.Provider.Port),
+		Addr:              localBindAddr(d.Provider.Host, fmt.Sprintf("%d", d.Provider.Port)),
 		ReadHeaderTimeout: 5 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			d.Logf("[DEBUG] dev oauth request %s %s %+v", r.Method, r.URL, r.Header)

--- a/v2/provider/service.go
+++ b/v2/provider/service.go
@@ -4,12 +4,27 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
 	"github.com/go-pkgz/auth/v2/avatar"
 	"github.com/go-pkgz/auth/v2/token"
 )
+
+// localBindAddr returns the listen address for the dev oauth and custom-server
+// helpers. Both servers are intended for local development and embedded
+// flows; the historical default ":port" listened on every interface, which
+// silently exposed the dev OAuth UI to anyone on the LAN. Default the bind
+// to 127.0.0.1; callers that explicitly want a non-loopback bind can pass
+// a hostname (e.g. "0.0.0.0" or a specific IP) via Provider.Host (dev) or
+// the URL host (custom-server).
+func localBindAddr(host, port string) string {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, port)
+}
 
 const (
 	urlLoginSuffix    = "/login"

--- a/v2/provider/service_test.go
+++ b/v2/provider/service_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,6 +57,32 @@ func TestRandToken(t *testing.T) {
 	assert.NotEqual(t, "", s2)
 	assert.NotEqual(t, s2, s1)
 	t.Log(s2)
+}
+
+func TestLocalBindAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port string
+		want string
+	}{
+		{name: "empty host defaults to 127.0.0.1 (the security-relevant default)", host: "", port: "8080", want: "127.0.0.1:8080"},
+		{name: "explicit 127.0.0.1 honored", host: "127.0.0.1", port: "8080", want: "127.0.0.1:8080"},
+		{name: "explicit non-loopback honored (opt-in to LAN exposure)", host: "192.168.1.10", port: "8080", want: "192.168.1.10:8080"},
+		{name: "explicit 0.0.0.0 honored (caller is asking for it)", host: "0.0.0.0", port: "8080", want: "0.0.0.0:8080"},
+		{name: "ipv6 hostname is bracketed by net.JoinHostPort", host: "::1", port: "8080", want: "[::1]:8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, localBindAddr(tt.host, tt.port))
+		})
+	}
+}
+
+func TestLocalBindAddr_DefaultIsNotAllInterfaces(t *testing.T) {
+	addr := localBindAddr("", "12345")
+	assert.NotEqual(t, ":12345", addr, "default bind must not be all-interfaces")
+	assert.False(t, strings.HasPrefix(addr, ":"), "default bind must include a hostname, not the bare-port shorthand")
 }
 
 func TestSetAvatar(t *testing.T) {


### PR DESCRIPTION
## Summary

`provider/dev_provider.go` and `provider/custom_server.go` listened with `Addr: ":port"`, which binds to every interface. The dev OAuth UI and the embedded go-oauth2/oauth2 helper are intended for local development and embedded flows, not for LAN exposure -- but the bare-port shorthand silently exposed them to anyone who could route to the host's other addresses (other LAN clients, Docker network siblings, kubernetes pods on the same node, etc.).

## Change

Add `localBindAddr(host, port)` in `provider/service.go` that defaults the listen host to `127.0.0.1` when the caller passes an empty host. Callers that explicitly want non-loopback exposure can pass a hostname:

- **dev_provider** -- uses `Provider.Host` (existing field) as the host; empty -> `127.0.0.1`, explicit `"0.0.0.0"`/`"192.168.x.y"` honored.
- **custom_server** -- uses the host from `c.URL` (`http://localhost:8080`); `"localhost"` or empty -> `127.0.0.1`; explicit non-loopback honored.

Same change in v1 and v2 in single PR.

README updated with a "Listen address" section documenting:
- the security rationale for the localhost default;
- how to opt back in to all-interfaces binding (`AddDevProvider("0.0.0.0", port)` for dev; `URL: "http://0.0.0.0:port"` for custom server);
- the typical Docker case -- a server bound to `127.0.0.1` inside a container is not reachable from the host, so `0.0.0.0` is the right value when the auth process runs in a container.

Also fixed an outdated `AddDevProvider(port)` reference in the README -- the function takes `(host, port)`.

## Test

- `TestLocalBindAddr` -- table covering empty / explicit-loopback / explicit-LAN / explicit-`0.0.0.0` / IPv6.
- **Regression test:** `TestLocalBindAddr_DefaultIsNotAllInterfaces` -- asserts the default bind never produces the `":port"` shorthand. Reverting the helper to `return ":" + port` makes this test fail with: `Should not be: ":12345" -- default bind must not be all-interfaces`.

Both modules; `go test -race ./...` green; `golangci-lint run --new-from-rev=master` 0 issues.

## Migration note

Existing deployments that *intentionally* exposed the dev OAuth helper or custom server beyond loopback need to set `Provider.Host = "0.0.0.0"` (dev) or change their `Opts.URL` host to `0.0.0.0`/specific IP (custom-server). Default behaviour change is the security-relevant point of this PR.