### PR TITLE
Cap avatar fetch body size, pin redirect-validator bypass categories

### DIFF
--- a/avatar/avatar.go
+++ b/avatar/avatar.go
@@ -26,6 +26,12 @@ import (
 // http.sniffLen is 512 bytes which is how much we need to read to detect content type
 const sniffLen = 512
 
+// maxAvatarFetchSize bounds the bytes read from a remote avatar URL. 10 MiB is
+// generous for any reasonable avatar (Telegram caps photo at 5 MiB; Gravatar is
+// much smaller); the cap protects Proxy.Put against an upstream sending an
+// unbounded body that would exhaust process memory inside resize.
+const maxAvatarFetchSize = 10 << 20
+
 // Proxy provides http handler for avatars from avatar.Store
 // On user login token will call Put and it will retrieve and save picture locally.
 type Proxy struct {
@@ -98,7 +104,17 @@ func (p *Proxy) load(url string, client *http.Client) (rc io.ReadCloser, err err
 		return nil, fmt.Errorf("failed to get avatar from the orig, status %s", resp.Status)
 	}
 
-	return resp.Body, nil
+	// buffer the body up to the cap to fail fast on oversized inputs.
+	// Reading +1 byte beyond the cap distinguishes "exactly cap" from "too big".
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAvatarFetchSize+1))
+	_ = resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read avatar body: %w", err)
+	}
+	if int64(len(body)) > maxAvatarFetchSize {
+		return nil, fmt.Errorf("avatar body exceeds %d bytes", maxAvatarFetchSize)
+	}
+	return io.NopCloser(bytes.NewReader(body)), nil
 }
 
 // Handler returns token routes for given provider

--- a/avatar/avatar_test.go
+++ b/avatar/avatar_test.go
@@ -103,6 +103,32 @@ func TestAvatar_PutFailed(t *testing.T) {
 	assert.Equal(t, int64(992), fi.Size())
 }
 
+func TestAvatar_PutCapsBodySize(t *testing.T) {
+	// upstream that streams indefinitely past the cap; without
+	// cappedReadCloser the resize loop would read until OOM.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/*")
+		w.WriteHeader(http.StatusOK)
+		buf := make([]byte, 64<<10)
+		// write ~12 MiB which is over the 10 MiB cap
+		for i := 0; i < (maxAvatarFetchSize/len(buf))+32; i++ {
+			if _, err := w.Write(buf); err != nil {
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	p := Proxy{RoutePath: "/avatar", URL: "http://localhost:8080", Store: NewLocalFS(dir), L: logger.NoOp}
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	u := token.User{ID: "user1", Name: "huge avatar", Picture: ts.URL + "/pic.png"}
+	res, err := p.Put(u, client)
+	require.NoError(t, err, "Put falls back to identicon on capped fetch failure")
+	assert.Contains(t, res, "/avatar/", "still returns a proxy URL via identicon fallback")
+}
+
 func TestAvatar_Routes(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/v2/avatar/avatar.go
+++ b/v2/avatar/avatar.go
@@ -26,6 +26,12 @@ import (
 // http.sniffLen is 512 bytes which is how much we need to read to detect content type
 const sniffLen = 512
 
+// maxAvatarFetchSize bounds the bytes read from a remote avatar URL. 10 MiB is
+// generous for any reasonable avatar (Telegram caps photo at 5 MiB; Gravatar is
+// much smaller); the cap protects Proxy.Put against an upstream sending an
+// unbounded body that would exhaust process memory inside resize.
+const maxAvatarFetchSize = 10 << 20
+
 // Proxy provides http handler for avatars from avatar.Store
 // On user login token will call Put and it will retrieve and save picture locally.
 type Proxy struct {
@@ -98,7 +104,17 @@ func (p *Proxy) load(url string, client *http.Client) (rc io.ReadCloser, err err
 		return nil, fmt.Errorf("failed to get avatar from the orig, status %s", resp.Status)
 	}
 
-	return resp.Body, nil
+	// buffer the body up to the cap to fail fast on oversized inputs.
+	// Reading +1 byte beyond the cap distinguishes "exactly cap" from "too big".
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAvatarFetchSize+1))
+	_ = resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read avatar body: %w", err)
+	}
+	if int64(len(body)) > maxAvatarFetchSize {
+		return nil, fmt.Errorf("avatar body exceeds %d bytes", maxAvatarFetchSize)
+	}
+	return io.NopCloser(bytes.NewReader(body)), nil
 }
 
 // Handler returns token routes for given provider

--- a/v2/avatar/avatar_test.go
+++ b/v2/avatar/avatar_test.go
@@ -103,6 +103,29 @@ func TestAvatar_PutFailed(t *testing.T) {
 	assert.Equal(t, int64(992), fi.Size())
 }
 
+func TestAvatar_PutCapsBodySize(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/*")
+		w.WriteHeader(http.StatusOK)
+		buf := make([]byte, 64<<10)
+		for i := 0; i < (maxAvatarFetchSize/len(buf))+32; i++ {
+			if _, err := w.Write(buf); err != nil {
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	p := Proxy{RoutePath: "/avatar", URL: "http://localhost:8080", Store: NewLocalFS(dir), L: logger.NoOp}
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	u := token.User{ID: "user1", Name: "huge avatar", Picture: ts.URL + "/pic.png"}
+	res, err := p.Put(u, client)
+	require.NoError(t, err, "Put falls back to identicon on capped fetch failure")
+	assert.Contains(t, res, "/avatar/", "still returns a proxy URL via identicon fallback")
+}
+
 func TestAvatar_Routes(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/v2/provider/redirect_test.go
+++ b/v2/provider/redirect_test.go
@@ -65,6 +65,32 @@ func TestIsAllowedRedirect(t *testing.T) {
 			allowed: allowedFn("admin.example.com"), want: true},
 		{name: "malformed service URL with empty allowlist rejects", from: "https://admin.example.com", serviceURL: "://bad",
 			allowed: allowedFn(), want: false},
+
+		// bypass-category characterization. None of these URLs grant access to
+		// hosts outside the allowlist; the test pins that behavior so a future
+		// refactor of url.Parse usage doesn't silently weaken it.
+		{name: "scheme-relative URL rejected (no scheme)", from: "//evil.com/x", serviceURL: "https://app.example.com",
+			allowed: allowedFn("admin.example.com"), want: false},
+		{name: "userinfo does not bypass: allowed-looking user, evil host", from: "https://admin.example.com@evil.com/x",
+			serviceURL: "https://app.example.com", allowed: allowedFn("admin.example.com"), want: false},
+		{name: "userinfo does not change allowed host check (evil userinfo, allowed host)", from: "https://evil@admin.example.com/x",
+			serviceURL: "https://app.example.com", allowed: allowedFn("admin.example.com"), want: true},
+		{name: "IPv6 literal not in allowlist rejected", from: "https://[::1]/x", serviceURL: "https://app.example.com",
+			allowed: allowedFn("admin.example.com"), want: false},
+		{name: "IPv6 literal explicitly allowed", from: "https://[::1]/x", serviceURL: "https://app.example.com",
+			allowed: allowedFn("::1"), want: true},
+		{name: "IDN homoglyph not equal to ASCII allowlist entry", from: "https://аpp.example.com/x", serviceURL: "https://app.example.com",
+			allowed: allowedFn("app.example.com"), want: false},
+		{name: "punycode form of homoglyph not equal to ASCII allowlist entry", from: "https://xn--pp-7lc.example.com/x",
+			serviceURL: "https://app.example.com", allowed: allowedFn("app.example.com"), want: false},
+		{name: "percent-encoded host parse-fails rejected", from: "https://%65vil.com/x", serviceURL: "https://app.example.com",
+			allowed: allowedFn("admin.example.com"), want: false},
+		{name: "backslash userinfo trick parse-fails rejected", from: "https://evil.com\\@admin.example.com/x",
+			serviceURL: "https://app.example.com", allowed: allowedFn("admin.example.com"), want: false},
+		{name: "scheme without // (opaque) rejected", from: "https:evil.com/x", serviceURL: "https://app.example.com",
+			allowed: allowedFn("admin.example.com"), want: false},
+		{name: "triple-slash empties host rejected", from: "https:///evil.com/x", serviceURL: "https://app.example.com",
+			allowed: allowedFn("admin.example.com"), want: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Hardening followups from the security review of #275-#286 that don't fold into any of the four open security PRs.

### 1. `avatar.Proxy.Put` body-size cap (`avatar/avatar.go`, `v2/avatar/avatar.go`)

`Proxy.load` previously streamed the remote avatar `resp.Body` directly into `resize` without any cap. A malicious or buggy upstream sending an unbounded body could exhaust process memory.

This PR adds a 10 MiB cap (`maxAvatarFetchSize`):
- buffer the body through `io.ReadAll(io.LimitReader(resp.Body, maxAvatarFetchSize+1))` -- the +1 byte distinguishes "exactly at cap" from "too big".
- on overflow, return an error -- `Proxy.Put` then falls back to identicon as it does for any other load failure.
- legitimate avatars fit comfortably (Telegram caps photo at 5 MiB, Gravatar much smaller).

Test: `TestAvatar_PutCapsBodySize` simulates an upstream streaming ~12 MiB and asserts the user still gets a proxy URL (via identicon fallback) without OOM.

### 2. `isAllowedRedirect` bypass-category characterization tests (`v2/provider/redirect_test.go`)

Reviewer on #282 flagged untested bypass categories for the redirect validator. Verified manually that each is correctly rejected by the current `url.Parse` + `Hostname()` semantics; this PR pins that behaviour with a table of cases:

- scheme-relative `//evil.com/x`
- userinfo bypass `https://admin.example.com@evil.com/x`
- userinfo doesn't strip allowed host `https://evil@admin.example.com/x` (still allowed -- userinfo is irrelevant)
- IPv6 literal `https://[::1]/x` (rejected unless explicitly listed)
- IDN homoglyph (cyrillic `а`) and its punycode form not equal to ASCII allowlist entry
- percent-encoded host parse-fails
- backslash-userinfo trick parse-fails
- opaque `scheme:host` forms (`https:evil.com`, `https:///evil.com`)

Pure characterization tests -- no behaviour change, just guardrails so a future refactor doesn't silently weaken the validator.

## Items deferred to a separate followup once base PRs land

These touch code introduced by the open PRs (file doesn't yet exist on master), so they need to wait:

| Item | Depends on |
|---|---|
| `saveTelegramAvatar` body-size cap (mirror of the `Proxy.Put` cap above) | #286 |
| `botTokenInURLPath` regex anchoring (`/bot…/` vs `bot…` to stop matching `botFather`) | #286 |
| Rename `dumbAvatarSaver` test type to `legacyAvatarSaver` | #286 |
| Mirror these v2 bypass-category tests to v1 `provider/redirect_test.go` | #282 |
| v2 `validateAppleIDClaims` -> jwt v5 parser-options refactor (~70 lines drop) | #280 |

The HTTP client reuse nit on `saveTelegramAvatar` (#286 review item 6d) is intentionally skipped -- threading a shared `*http.Client` through the handler adds API surface for a one-call-per-login optimisation.