### PR TITLE
fix(verify): close service-level typed-nil store + adapter-author guidance

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -27,15 +27,15 @@ type Client struct {
 
 // Service provides higher level wrapper allowing to construct everything and get back token middleware
 type Service struct {
-	logger             logger.L
-	opts               Opts
-	jwtService         *token.Service
-	providers          []provider.Service
-	authMiddleware     middleware.Authenticator
-	avatarProxy        *avatar.Proxy
-	issuer             string
-	useGravatar        bool
-	verifConfirmStore  provider.VerifConfirmationStore
+	logger                logger.L
+	opts                  Opts
+	jwtService            *token.Service
+	providers             []provider.Service
+	authMiddleware        middleware.Authenticator
+	avatarProxy           *avatar.Proxy
+	issuer                string
+	useGravatar           bool
+	verifConfirmStore     provider.VerifConfirmationStore
 	verifConfirmStoreOnce sync.Once
 }
 
@@ -447,8 +447,16 @@ func (s *Service) AddDirectProviderWithUserIDFunc(name string, credChecker provi
 // AddVerifProvider adds provider user's verification sent by sender
 func (s *Service) AddVerifProvider(name, msgTmpl string, sender provider.Sender) {
 	s.verifConfirmStoreOnce.Do(func() {
-		if s.opts.VerifConfirmationStore != nil {
-			s.verifConfirmStore = s.opts.VerifConfirmationStore
+		store := s.opts.VerifConfirmationStore
+		// guard against a typed-nil VerifConfirmationStoreFunc: a non-nil
+		// interface wrapping a nil func would survive the != nil check below
+		// and silently disable replay protection (the handler-level guard
+		// at LoginHandler then normalizes it to nil).
+		if fn, ok := store.(provider.VerifConfirmationStoreFunc); ok && fn == nil {
+			store = nil
+		}
+		if store != nil {
+			s.verifConfirmStore = store
 			return
 		}
 		s.verifConfirmStore = provider.NewInMemoryVerifStore()

--- a/auth_test.go
+++ b/auth_test.go
@@ -129,6 +129,25 @@ func TestService_AddVerifProvider_UsesCustomConfirmationStore(t *testing.T) {
 	assert.Same(t, custom, svc.verifConfirmStore, "custom store from Opts must be used, not the in-memory default")
 }
 
+func TestService_AddVerifProvider_TypedNilStoreFuncFallsBackToDefault(t *testing.T) {
+	// Opts.VerifConfirmationStore set to a typed-nil VerifConfirmationStoreFunc
+	// is a non-nil interface wrapping a nil func. Without a service-level
+	// guard the != nil check at AddVerifProvider succeeds, NewInMemoryVerifStore
+	// is skipped, and the handler-level guard then normalizes the typed-nil to
+	// nil at redemption -- net result is replay protection silently disabled.
+	var nilFn provider.VerifConfirmationStoreFunc
+	svc := NewService(Opts{
+		SecretReader:           token.SecretFunc(func(string) (string, error) { return "secret", nil }),
+		URL:                    "http://127.0.0.1",
+		Logger:                 logger.Std,
+		VerifConfirmationStore: nilFn,
+	})
+	svc.AddVerifProvider("email", "{{.Token}}", provider.SenderFunc(func(string, string) error { return nil }))
+	require.NotNil(t, svc.verifConfirmStore, "typed-nil func must fall back to in-memory default, not silently disable protection")
+	_, ok := svc.verifConfirmStore.(provider.VerifConfirmationStoreFunc)
+	assert.False(t, ok, "fallback must be the in-memory default, not the typed-nil func itself")
+}
+
 func TestService_AddVerifProvider_DefaultsToInMemory(t *testing.T) {
 	svc := NewService(Opts{
 		SecretReader: token.SecretFunc(func(string) (string, error) { return "secret", nil }),

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -70,6 +70,13 @@ type VerifConfirmationStore interface {
 	// valid reopens the replay window the store is meant to close. err
 	// signals a backend failure (network, disk, capacity, etc.); callers
 	// MUST treat a non-nil err as fail-closed (reject the redemption).
+	//
+	// Adapter authors: do NOT embed key (or any caller-supplied data) in
+	// returned errors. The handler logs err on the fail-closed branch, and
+	// although key is the SHA-256 of the raw token rather than the token
+	// itself, it still uniquely identifies the live, unredeemed JWT in
+	// log destinations. Wrap the underlying backend error with a generic
+	// description (e.g. "redis SET failed: %w") instead.
 	MarkUsed(key string, ttl time.Duration) (alreadyUsed bool, err error)
 }
 

--- a/provider/verify_test.go
+++ b/provider/verify_test.go
@@ -338,6 +338,26 @@ func TestInMemoryVerifStore(t *testing.T) {
 	})
 }
 
+func TestScrubTokenFromRequest(t *testing.T) {
+	t.Run("token query is replaced with redacted sentinel", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/login?token=secret-jwt&sess=1", http.NoBody)
+		require.NoError(t, err)
+		out := scrubTokenFromRequest(req)
+		assert.Equal(t, "secret-jwt", req.URL.Query().Get("token"), "original request must not be mutated")
+		assert.Equal(t, "<redacted>", out.URL.Query().Get("token"))
+		assert.Equal(t, "1", out.URL.Query().Get("sess"), "other query params preserved")
+	})
+	t.Run("missing token query returns request unchanged", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/login?sess=1", http.NoBody)
+		require.NoError(t, err)
+		out := scrubTokenFromRequest(req)
+		assert.Same(t, req, out)
+	})
+	t.Run("nil request returns nil", func(t *testing.T) {
+		assert.Nil(t, scrubTokenFromRequest(nil))
+	})
+}
+
 func TestVerifConfirmationStoreFunc(t *testing.T) {
 	calls := 0
 	var lastKey string

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -27,15 +27,15 @@ type Client struct {
 
 // Service provides higher level wrapper allowing to construct everything and get back token middleware
 type Service struct {
-	logger             logger.L
-	opts               Opts
-	jwtService         *token.Service
-	providers          []provider.Service
-	authMiddleware     middleware.Authenticator
-	avatarProxy        *avatar.Proxy
-	issuer             string
-	useGravatar        bool
-	verifConfirmStore  provider.VerifConfirmationStore
+	logger                logger.L
+	opts                  Opts
+	jwtService            *token.Service
+	providers             []provider.Service
+	authMiddleware        middleware.Authenticator
+	avatarProxy           *avatar.Proxy
+	issuer                string
+	useGravatar           bool
+	verifConfirmStore     provider.VerifConfirmationStore
 	verifConfirmStoreOnce sync.Once
 }
 
@@ -448,8 +448,16 @@ func (s *Service) AddDirectProviderWithUserIDFunc(name string, credChecker provi
 // AddVerifProvider adds provider user's verification sent by sender
 func (s *Service) AddVerifProvider(name, msgTmpl string, sender provider.Sender) {
 	s.verifConfirmStoreOnce.Do(func() {
-		if s.opts.VerifConfirmationStore != nil {
-			s.verifConfirmStore = s.opts.VerifConfirmationStore
+		store := s.opts.VerifConfirmationStore
+		// guard against a typed-nil VerifConfirmationStoreFunc: a non-nil
+		// interface wrapping a nil func would survive the != nil check below
+		// and silently disable replay protection (the handler-level guard
+		// at LoginHandler then normalizes it to nil).
+		if fn, ok := store.(provider.VerifConfirmationStoreFunc); ok && fn == nil {
+			store = nil
+		}
+		if store != nil {
+			s.verifConfirmStore = store
 			return
 		}
 		s.verifConfirmStore = provider.NewInMemoryVerifStore()

--- a/v2/auth_test.go
+++ b/v2/auth_test.go
@@ -129,6 +129,25 @@ func TestService_AddVerifProvider_UsesCustomConfirmationStore(t *testing.T) {
 	assert.Same(t, custom, svc.verifConfirmStore, "custom store from Opts must be used, not the in-memory default")
 }
 
+func TestService_AddVerifProvider_TypedNilStoreFuncFallsBackToDefault(t *testing.T) {
+	// Opts.VerifConfirmationStore set to a typed-nil VerifConfirmationStoreFunc
+	// is a non-nil interface wrapping a nil func. Without a service-level
+	// guard the != nil check at AddVerifProvider succeeds, NewInMemoryVerifStore
+	// is skipped, and the handler-level guard then normalizes the typed-nil to
+	// nil at redemption -- net result is replay protection silently disabled.
+	var nilFn provider.VerifConfirmationStoreFunc
+	svc := NewService(Opts{
+		SecretReader:           token.SecretFunc(func(string) (string, error) { return "secret", nil }),
+		URL:                    "http://127.0.0.1",
+		Logger:                 logger.Std,
+		VerifConfirmationStore: nilFn,
+	})
+	svc.AddVerifProvider("email", "{{.Token}}", provider.SenderFunc(func(string, string) error { return nil }))
+	require.NotNil(t, svc.verifConfirmStore, "typed-nil func must fall back to in-memory default, not silently disable protection")
+	_, ok := svc.verifConfirmStore.(provider.VerifConfirmationStoreFunc)
+	assert.False(t, ok, "fallback must be the in-memory default, not the typed-nil func itself")
+}
+
 func TestService_AddVerifProvider_DefaultsToInMemory(t *testing.T) {
 	svc := NewService(Opts{
 		SecretReader: token.SecretFunc(func(string) (string, error) { return "secret", nil }),

--- a/v2/provider/verify.go
+++ b/v2/provider/verify.go
@@ -70,6 +70,13 @@ type VerifConfirmationStore interface {
 	// valid reopens the replay window the store is meant to close. err
 	// signals a backend failure (network, disk, capacity, etc.); callers
 	// MUST treat a non-nil err as fail-closed (reject the redemption).
+	//
+	// Adapter authors: do NOT embed key (or any caller-supplied data) in
+	// returned errors. The handler logs err on the fail-closed branch, and
+	// although key is the SHA-256 of the raw token rather than the token
+	// itself, it still uniquely identifies the live, unredeemed JWT in
+	// log destinations. Wrap the underlying backend error with a generic
+	// description (e.g. "redis SET failed: %w") instead.
 	MarkUsed(key string, ttl time.Duration) (alreadyUsed bool, err error)
 }
 

--- a/v2/provider/verify_test.go
+++ b/v2/provider/verify_test.go
@@ -259,6 +259,26 @@ func TestInMemoryVerifStore(t *testing.T) {
 	})
 }
 
+func TestScrubTokenFromRequest(t *testing.T) {
+	t.Run("token query is replaced with redacted sentinel", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/login?token=secret-jwt&sess=1", http.NoBody)
+		require.NoError(t, err)
+		out := scrubTokenFromRequest(req)
+		assert.Equal(t, "secret-jwt", req.URL.Query().Get("token"), "original request must not be mutated")
+		assert.Equal(t, "<redacted>", out.URL.Query().Get("token"))
+		assert.Equal(t, "1", out.URL.Query().Get("sess"), "other query params preserved")
+	})
+	t.Run("missing token query returns request unchanged", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/login?sess=1", http.NoBody)
+		require.NoError(t, err)
+		out := scrubTokenFromRequest(req)
+		assert.Same(t, req, out)
+	})
+	t.Run("nil request returns nil", func(t *testing.T) {
+		assert.Nil(t, scrubTokenFromRequest(nil))
+	})
+}
+
 func TestVerifConfirmationStoreFunc(t *testing.T) {
 	calls := 0
 	var lastKey string


### PR DESCRIPTION
## Summary

Followups to #281 raised on the post-merge review. None blocking, all small.

| # | Item | Where |
|---|---|---|
| 1 | **Service-level typed-nil `VerifConfirmationStoreFunc` guard** -- silently disabled replay protection for `Opts{VerifConfirmationStore: VerifConfirmationStoreFunc(nil)}` | `auth.go`, `v2/auth.go` (+ tests) |
| 2 | `gofmt -w` after the `verifConfirmStoreO` -> `verifConfirmStoreOnce` rename | `auth.go`, `v2/auth.go` |
| 3 | Unit test for `scrubTokenFromRequest` -- the defensive early-return was uncovered after #281 | `provider/verify_test.go`, `v2/provider/verify_test.go` |
| 4 | Adapter-author godoc note on `MarkUsed` -- don't embed key in returned errors | `provider/verify.go`, `v2/provider/verify.go` |

## Item 1 in detail

The handler-level guard added in #281 round 2 (`provider/verify.go` LoginHandler) correctly normalises a typed-nil `VerifConfirmationStoreFunc` to no-store, but the Service-level check in `AddVerifProvider` was still:

```go
if s.opts.VerifConfirmationStore != nil {
    s.verifConfirmStore = s.opts.VerifConfirmationStore
    return
}
s.verifConfirmStore = provider.NewInMemoryVerifStore()
```

A typed-nil `VerifConfirmationStoreFunc` is a non-nil interface wrapping a nil func, so it survives the `!= nil` check, `NewInMemoryVerifStore()` is skipped, and at redemption time the handler-level guard then normalises the typed-nil to nil. **Net effect:** a user writing `Opts{VerifConfirmationStore: VerifConfirmationStoreFunc(nil)}` gets neither their func nor the default in-memory store, and replay protection is silently disabled.

Same shape as the `*avatar.Proxy` typed-nil case fixed in #286, with a different consequence (silent loss of protection rather than panic). The fix is the same shape applied one layer up:

```go
s.verifConfirmStoreOnce.Do(func() {
    store := s.opts.VerifConfirmationStore
    if fn, ok := store.(provider.VerifConfirmationStoreFunc); ok && fn == nil {
        store = nil
    }
    if store != nil {
        s.verifConfirmStore = store
        return
    }
    s.verifConfirmStore = provider.NewInMemoryVerifStore()
})
```

Regression test `TestService_AddVerifProvider_TypedNilStoreFuncFallsBackToDefault` in both v1 and v2: writes `var nilFn provider.VerifConfirmationStoreFunc; ConfirmationStore: nilFn`, asserts `verifConfirmStore` is non-nil and is **not** the typed-nil func itself (i.e. the default fired).

## Test

`go test -race ./...` green in both modules; `golangci-lint run --enable-only=misspell ./...` clean.