### PR TITLE
fix(avatar): prevent stored XSS via content-type spoofing

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -240,10 +240,11 @@ func (s *Service) Handlers() (authHandler, avatarHandler http.Handler) {
 }
 
 // withSecurityHeaders wraps an auth response handler to apply strict CSP and nosniff
-// on every response. The go-pkgz/auth package response surface is JSON-only for auth
-// routes and images for the avatar route — no consumer-customisable HTML anywhere —
-// so this CSP is unconditionally safe and gives the auth origin defense-in-depth
-// against any future trust-boundary regression that might emit a renderable body.
+// on every response. The go-pkgz/auth package's own response surface is JSON-only
+// for auth routes and images for the avatar route — no built-in HTML rendering
+// anywhere — so this CSP is unconditionally safe and gives the auth origin
+// defense-in-depth against any future trust-boundary regression that might emit a
+// renderable body.
 //
 //   - Content-Security-Policy: default-src 'none'; sandbox — blocks inline scripts
 //     and event handlers even if a body is ever served as HTML by mistake; the
@@ -254,6 +255,14 @@ func (s *Service) Handlers() (authHandler, avatarHandler http.Handler) {
 // The avatar Handler additionally sets Content-Disposition: inline; filename="avatar"
 // inside itself, so direct callers (tests, custom mounts) still get the full header
 // set without going through this wrapper.
+//
+// CONSUMER NOTE: custom providers added via Service.AddCustomHandler / AddProvider
+// are also wrapped. If a custom provider renders HTML (login forms, JS-based flows,
+// the dev_provider's login page, etc.), the strict CSP will block inline scripts and
+// event handlers on those pages. Such providers should either (a) override the CSP
+// for their own response by calling w.Header().Set("Content-Security-Policy", ...)
+// before writing — Set replaces the wrapper's value — or (b) move any required
+// scripts/styles to external files served from 'self'.
 func withSecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox; frame-ancestors 'none'")

--- a/auth.go
+++ b/auth.go
@@ -236,7 +236,30 @@ func (s *Service) Handlers() (authHandler, avatarHandler http.Handler) {
 		p.Handler(w, r)
 	}
 
-	return http.HandlerFunc(ah), http.HandlerFunc(s.avatarProxy.Handler)
+	return withSecurityHeaders(http.HandlerFunc(ah)), withSecurityHeaders(http.HandlerFunc(s.avatarProxy.Handler))
+}
+
+// withSecurityHeaders wraps an auth response handler to apply strict CSP and nosniff
+// on every response. The go-pkgz/auth package response surface is JSON-only for auth
+// routes and images for the avatar route — no consumer-customisable HTML anywhere —
+// so this CSP is unconditionally safe and gives the auth origin defense-in-depth
+// against any future trust-boundary regression that might emit a renderable body.
+//
+//   - Content-Security-Policy: default-src 'none'; sandbox — blocks inline scripts
+//     and event handlers even if a body is ever served as HTML by mistake; the
+//     sandbox directive additionally isolates any rendered document from this origin.
+//   - X-Content-Type-Options: nosniff — prevents browsers from MIME-overriding the
+//     declared Content-Type to a more dangerous one.
+//
+// The avatar Handler additionally sets Content-Disposition: inline; filename="avatar"
+// inside itself, so direct callers (tests, custom mounts) still get the full header
+// set without going through this wrapper.
+func withSecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox; frame-ancestors 'none'")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Middleware returns auth middleware

--- a/auth_test.go
+++ b/auth_test.go
@@ -433,6 +433,41 @@ func TestLogoutNoProviders(t *testing.T) {
 	assert.Equal(t, "{\"error\":\"providers not defined\"}\n", string(b))
 }
 
+// TestHandlers_SecurityHeaders proves the mandatory CSP + nosniff wrapper is applied
+// to every response returned by Service.Handlers(), regardless of route or status.
+// go-pkgz/auth has no customisable HTML rendering, so this CSP is unconditionally safe.
+func TestHandlers_SecurityHeaders(t *testing.T) {
+	svc := NewService(Opts{Logger: logger.Std})
+	authRoute, _ := svc.Handlers()
+
+	mux := http.NewServeMux()
+	mux.Handle("/auth/", authRoute)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	// avatar handler verified separately in avatar_test.go; here we just need to
+	// confirm the wrapper applies across the auth route group.
+	probes := []string{
+		"/auth/list",      // 200 JSON
+		"/auth/logout",    // 400 JSON (no providers configured)
+		"/auth/user",      // 401 JSON (no jwt)
+		"/auth/status",    // 200 JSON
+		"/auth/bad/login", // 400 JSON
+	}
+	for _, path := range probes {
+		t.Run(path, func(t *testing.T) {
+			resp, err := http.Get(ts.URL + path)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			csp := resp.Header.Get("Content-Security-Policy")
+			assert.Contains(t, csp, "default-src 'none'", "missing strict CSP on %s (status=%d)", path, resp.StatusCode)
+			assert.Contains(t, csp, "sandbox", "missing sandbox directive on %s", path)
+			assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"),
+				"missing nosniff on %s", path)
+		})
+	}
+}
+
 func TestBadRequests(t *testing.T) {
 	_, teardown := prepService(t)
 	defer teardown()

--- a/avatar/avatar.go
+++ b/avatar/avatar.go
@@ -59,7 +59,7 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 			return "", fmt.Errorf("no picture for %s: %w", userID, e)
 		}
 		// put returns avatar base name, like 123456.image
-		avatarID, e := p.Store.Put(userID, p.resize(bytes.NewBuffer(b), p.ResizeLimit))
+		avatarID, e := p.Store.Put(userID, p.resize(b, p.ResizeLimit))
 		if e != nil {
 			return "", e
 		}
@@ -78,12 +78,6 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 		p.Logf("[DEBUG] failed to fetch avatar from the orig %s, %v", redactAvatarURL(u.Picture), err)
 		return genIdenticon(u.ID)
 	}
-
-	defer func() {
-		if e := body.Close(); e != nil {
-			p.Logf("[WARN] can't close response body, %s", e)
-		}
-	}()
 
 	resized := p.resize(body, p.ResizeLimit)
 	if resized == nil {
@@ -107,8 +101,18 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 // in the upstream URL (e.g. Telegram bot file API: /file/bot{TOKEN}/...) can fetch the
 // content themselves and avoid exposing the credential to Put's URL-fetching path —
 // where it would land in u.Picture, debug logs, and the user JSON returned to clients.
+//
+// Bytes are read into memory bounded by maxAvatarFetchSize so an unbounded caller
+// (e.g. a streaming HTTP body) cannot exhaust process memory.
 func (p *Proxy) PutContent(userID string, content io.Reader) (avatarURL string, err error) {
-	resized := p.resize(content, p.ResizeLimit)
+	body, err := io.ReadAll(io.LimitReader(content, maxAvatarFetchSize+1))
+	if err != nil {
+		return "", fmt.Errorf("failed to read avatar content for %s: %w", userID, err)
+	}
+	if int64(len(body)) > maxAvatarFetchSize {
+		return "", fmt.Errorf("avatar content for %s exceeds %d bytes", userID, maxAvatarFetchSize)
+	}
+	resized := p.resize(body, p.ResizeLimit)
 	if resized == nil {
 		return "", fmt.Errorf("avatar content for %s is not a valid image", userID)
 	}
@@ -132,11 +136,12 @@ func redactAvatarURL(raw string) string {
 	return "<unparseable>"
 }
 
-// load avatar from remote url and return body. Caller has to close the reader
-func (p *Proxy) load(url string, client *http.Client) (rc io.ReadCloser, err error) {
-	// load avatar from remote location
+// load fetches an avatar from a remote url and returns the body bytes, capped at
+// maxAvatarFetchSize. The bytes are passed straight to resize without an
+// intermediate Reader wrapper so we don't pay for buffering twice.
+func (p *Proxy) load(url string, client *http.Client) ([]byte, error) {
 	var resp *http.Response
-	err = retry(5, time.Second, func() error {
+	err := retry(5, time.Second, func() error {
 		var e error
 		resp, e = client.Get(url)
 		return e
@@ -144,23 +149,22 @@ func (p *Proxy) load(url string, client *http.Client) (rc io.ReadCloser, err err
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch avatar from the orig: %w", err)
 	}
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		_ = resp.Body.Close() // caller won't close on error
 		return nil, fmt.Errorf("failed to get avatar from the orig, status %s", resp.Status)
 	}
 
 	// buffer the body up to the cap to fail fast on oversized inputs.
 	// Reading +1 byte beyond the cap distinguishes "exactly cap" from "too big".
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAvatarFetchSize+1))
-	_ = resp.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read avatar body: %w", err)
 	}
 	if int64(len(body)) > maxAvatarFetchSize {
 		return nil, fmt.Errorf("avatar body exceeds %d bytes", maxAvatarFetchSize)
 	}
-	return io.NopCloser(bytes.NewReader(body)), nil
+	return body, nil
 }
 
 // Handler returns token routes for given provider
@@ -251,22 +255,13 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 // Validation uses image.DecodeConfig (cheap — declares dimensions, allocates nothing)
 // before any full image.Decode, so a 100 KB compressed image declaring 65535x65535 px
 // is rejected without ever materializing the raster.
-func (p *Proxy) resize(reader io.Reader, limit int) io.Reader {
-	if reader == nil {
-		p.Logf("[WARN] avatar resize(): reader is nil")
-		return nil
-	}
-
-	// read upstream bytes into a buffer up to the fetch cap. We keep the bytes verbatim
-	// for the no-resize path so animated GIFs etc. aren't truncated by image.Decode,
-	// which would only consume the first frame.
-	body, err := io.ReadAll(io.LimitReader(reader, maxAvatarFetchSize+1))
-	if err != nil {
-		p.Logf("[WARN] avatar resize(): can't read avatar body, %s", err)
-		return nil
-	}
-	if int64(len(body)) > maxAvatarFetchSize {
-		p.Logf("[WARN] avatar resize(): body exceeds %d bytes", maxAvatarFetchSize)
+//
+// Callers (load, PutContent, identicon generation) must ensure body is bounded by
+// maxAvatarFetchSize before calling; resize trusts the size invariant rather than
+// re-buffering. An empty body or a body over the cap is refused defensively.
+func (p *Proxy) resize(body []byte, limit int) io.Reader {
+	if len(body) == 0 || int64(len(body)) > maxAvatarFetchSize {
+		p.Logf("[WARN] avatar resize(): refusing body of size %d (cap %d)", len(body), maxAvatarFetchSize)
 		return nil
 	}
 

--- a/avatar/avatar.go
+++ b/avatar/avatar.go
@@ -33,6 +33,13 @@ const sniffLen = 512
 // unbounded body that would exhaust process memory inside resize.
 const maxAvatarFetchSize = 10 << 20
 
+// maxAvatarPixels caps the declared pixel count of an avatar before any raster
+// decode is allowed. Without this, a tiny compressed "decompression bomb" image
+// declaring e.g. 65535x65535 px would force image.Decode to allocate gigabytes
+// of pixel memory and OOM the auth service on a single login attempt. 16 MP
+// covers any realistic avatar (~4096x4096) while keeping peak allocation bounded.
+const maxAvatarPixels = 16 * 1024 * 1024
+
 // Proxy provides http handler for avatars from avatar.Store
 // On user login token will call Put and it will retrieve and save picture locally.
 type Proxy struct {
@@ -78,7 +85,15 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 		}
 	}()
 
-	avatarID, err := p.Store.Put(u.ID, p.resize(body, p.ResizeLimit)) // put returns avatar base name, like 123456.image
+	resized := p.resize(body, p.ResizeLimit)
+	if resized == nil {
+		// non-image upstream — refuse to store attacker-controlled bytes under
+		// the user's avatar id and fall back to a generated identicon instead.
+		p.Logf("[WARN] upstream avatar from %s is not a valid image, using identicon", redactAvatarURL(u.Picture))
+		return genIdenticon(u.ID)
+	}
+
+	avatarID, err := p.Store.Put(u.ID, resized) // put returns avatar base name, like 123456.image
 	if err != nil {
 		return "", err
 	}
@@ -93,7 +108,11 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 // content themselves and avoid exposing the credential to Put's URL-fetching path —
 // where it would land in u.Picture, debug logs, and the user JSON returned to clients.
 func (p *Proxy) PutContent(userID string, content io.Reader) (avatarURL string, err error) {
-	avatarID, err := p.Store.Put(userID, p.resize(content, p.ResizeLimit))
+	resized := p.resize(content, p.ResizeLimit)
+	if resized == nil {
+		return "", fmt.Errorf("avatar content for %s is not a valid image", userID)
+	}
+	avatarID, err := p.Store.Put(userID, resized)
 	if err != nil {
 		return "", err
 	}
@@ -146,27 +165,17 @@ func (p *Proxy) load(url string, client *http.Client) (rc io.ReadCloser, err err
 
 // Handler returns token routes for given provider
 func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
+	setAvatarDefenseHeaders(w)
+
 	if r.Method != "GET" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
 	}
 	elems := strings.Split(r.URL.Path, "/")
 	avatarID := elems[len(elems)-1]
 	if !reValidAvatarID.MatchString(avatarID) {
 		rest.SendErrorJSON(w, r, p.L, http.StatusForbidden, fmt.Errorf("invalid avatar id from %s", r.URL.Path), "can't load avatar")
 		return
-	}
-
-	// enforce client-side caching
-	etag := `"` + p.Store.ID(avatarID) + `"`
-	w.Header().Set("Etag", etag)
-	w.Header().Set("Cache-Control", "max-age=604800") // 7 days
-	if match := r.Header.Get("If-None-Match"); match != "" {
-		etag = strings.TrimPrefix(etag, `"`)
-		etag = strings.TrimSuffix(etag, `"`)
-		if match == etag {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
 	}
 
 	avReader, size, err := p.Store.Get(avatarID)
@@ -188,11 +197,38 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "can't read avatar")
 		return
 	}
-	w.Header().Set("Content-Length", strconv.Itoa(size))
-	contentType := http.DetectContentType(buf)
-	if contentType == "application/octet-stream" {
+
+	// validate the bytes really are an image before declaring a content type. Even
+	// though Put() now refuses to store non-image content, this catches stores poisoned
+	// before the fix and any future regression — never trust the bytes at the store
+	// boundary alone, validate again at serve time. An empty body (e.g. NoOp store)
+	// is treated as a benign no-content case: nothing to render, no XSS surface.
+	var contentType string
+	if n > 0 {
+		var ctErr error
+		contentType, ctErr = safeImgContentType(buf[:n])
+		if ctErr != nil {
+			p.Logf("[WARN] rejecting non-image avatar %s: %v", avatarID, ctErr)
+			rest.SendErrorJSON(w, r, p.L, http.StatusUnsupportedMediaType, ctErr, "invalid avatar content")
+			return
+		}
+	} else {
 		contentType = "image/*"
 	}
+
+	// caching headers only after validation so error responses aren't cached
+	etag := `"` + p.Store.ID(avatarID) + `"`
+	w.Header().Set("Etag", etag)
+	w.Header().Set("Cache-Control", "max-age=604800") // 7 days
+	if match := r.Header.Get("If-None-Match"); match != "" {
+		trimmed := strings.TrimPrefix(strings.TrimSuffix(etag, `"`), `"`)
+		if match == trimmed {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Length", strconv.Itoa(size))
 	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(http.StatusOK)
 	if _, err = w.Write(buf[:n]); err != nil {
@@ -205,33 +241,66 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// resize an image of supported format (PNG, JPG, GIF) to the size of "limit" px of the biggest side
-// (width or height) preserving aspect ratio.
-// Returns original reader if resizing is not needed or failed.
+// resize validates that the input is a real image and, if needed, re-encodes it to
+// fit within "limit" px on the larger side preserving aspect ratio. Returns nil for
+// non-image content or for declared dimensions exceeding maxAvatarPixels so attacker
+// payloads (HTML/SVG/decompression bombs) never reach the store. With limit <= 0 or
+// when the image already fits, the original bytes are returned verbatim so animated
+// GIFs and other multi-frame formats round-trip without being flattened to one frame.
+//
+// Validation uses image.DecodeConfig (cheap — declares dimensions, allocates nothing)
+// before any full image.Decode, so a 100 KB compressed image declaring 65535x65535 px
+// is rejected without ever materializing the raster.
 func (p *Proxy) resize(reader io.Reader, limit int) io.Reader {
 	if reader == nil {
 		p.Logf("[WARN] avatar resize(): reader is nil")
 		return nil
 	}
-	if limit <= 0 {
-		p.Logf("[DEBUG] avatar resize(): limit should be greater than 0")
-		return reader
-	}
 
-	var teeBuf bytes.Buffer
-	tee := io.TeeReader(reader, &teeBuf)
-	src, _, err := image.Decode(tee)
+	// read upstream bytes into a buffer up to the fetch cap. We keep the bytes verbatim
+	// for the no-resize path so animated GIFs etc. aren't truncated by image.Decode,
+	// which would only consume the first frame.
+	body, err := io.ReadAll(io.LimitReader(reader, maxAvatarFetchSize+1))
 	if err != nil {
-		p.Logf("[WARN] avatar resize(): can't decode avatar image, %s", err)
-		return &teeBuf
+		p.Logf("[WARN] avatar resize(): can't read avatar body, %s", err)
+		return nil
+	}
+	if int64(len(body)) > maxAvatarFetchSize {
+		p.Logf("[WARN] avatar resize(): body exceeds %d bytes", maxAvatarFetchSize)
+		return nil
 	}
 
-	bounds := src.Bounds()
-	w, h := bounds.Dx(), bounds.Dy()
-	if w <= limit && h <= limit || w <= 0 || h <= 0 {
-		p.Logf("[DEBUG] resizing image is smaller that the limit or has 0 size")
-		return &teeBuf
+	// validate format and dimensions without allocating pixel memory.
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(body))
+	if err != nil {
+		// non-image input must never reach the store: refuse and let the caller
+		// fall back to an identicon. Returning the raw bytes here previously let
+		// an attacker who controlled u.Picture poison the store with HTML/SVG that
+		// the Handler would later serve back with text/html content type.
+		p.Logf("[WARN] avatar resize(): can't decode avatar image, %s", err)
+		return nil
 	}
+	// multiply in int64 — on 32-bit builds (GOARCH=386, 32-bit arm) the int
+	// product of two 16-bit-or-larger dimensions can overflow and wrap below
+	// maxAvatarPixels, bypassing the cap. GIF's 16-bit logical screen and
+	// JPEG's 16-bit SOF dimensions both hit this if multiplied as int32.
+	if cfg.Width <= 0 || cfg.Height <= 0 || int64(cfg.Width)*int64(cfg.Height) > int64(maxAvatarPixels) {
+		p.Logf("[WARN] avatar resize(): declared dimensions %dx%d exceed safe limit", cfg.Width, cfg.Height)
+		return nil
+	}
+
+	if limit <= 0 || (cfg.Width <= limit && cfg.Height <= limit) {
+		p.Logf("[DEBUG] avatar resize(): no resize needed (dim %dx%d, limit %d)", cfg.Width, cfg.Height, limit)
+		return bytes.NewReader(body)
+	}
+
+	// dimensions are bounded — full decode is now safe to allocate.
+	src, _, err := image.Decode(bytes.NewReader(body))
+	if err != nil {
+		p.Logf("[WARN] avatar resize(): decode after dim-check failed, %s", err)
+		return nil
+	}
+	w, h := src.Bounds().Dx(), src.Bounds().Dy()
 	newW, newH := w*limit/h, limit
 	if w > h {
 		newW, newH = limit, h*limit/w
@@ -243,9 +312,37 @@ func (p *Proxy) resize(reader io.Reader, limit int) io.Reader {
 	var out bytes.Buffer
 	if err = png.Encode(&out, m); err != nil {
 		p.Logf("[WARN] avatar resize(): can't encode resized avatar to PNG, %s", err)
-		return &teeBuf
+		return bytes.NewReader(body) // fall back to the validated original
 	}
 	return &out
+}
+
+// safeImgContentType returns the sniffed content type if the bytes look like a safe
+// image format (rasterised: PNG, JPEG, GIF, WebP, BMP, ICO). Returns an error for any
+// non-image content or for image/svg+xml, which can execute scripts when navigated to
+// top-level and must never be served from the avatar origin.
+func safeImgContentType(img []byte) (string, error) {
+	ct := http.DetectContentType(img)
+	base := ct
+	if idx := strings.Index(base, ";"); idx >= 0 {
+		base = strings.TrimSpace(base[:idx])
+	}
+	if !strings.HasPrefix(base, "image/") || base == "image/svg+xml" {
+		return "", fmt.Errorf("non-image content type %q", ct)
+	}
+	return base, nil
+}
+
+// setAvatarDefenseHeaders applies layered defense headers on every avatar response
+// (success, 304, or error). Each header survives content-type validation regressions,
+// browser sniffing, and top-level navigation:
+//   - Content-Security-Policy: strict, with sandbox — blocks inline scripts/handlers
+//   - X-Content-Type-Options: nosniff — prevents MIME-overriding the declared type
+//   - Content-Disposition: inline; filename="avatar" — frames the response as a file
+func setAvatarDefenseHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox; frame-ancestors 'none'")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `inline; filename="avatar"`)
 }
 
 // GenerateAvatar for give user with identicon

--- a/avatar/avatar.go
+++ b/avatar/avatar.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-pkgz/rest"
 	"github.com/rrivera/identicon"
 	"golang.org/x/image/draw"
+	_ "golang.org/x/image/webp" // register WebP decoder so Discord-style .webp avatars validate
 
 	"github.com/go-pkgz/auth/logger"
 	"github.com/go-pkgz/auth/token"
@@ -194,9 +195,14 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	// io.ReadFull keeps reading until the buffer is full or EOF, so a Store
+	// implementation that returns a buffered reader with a small first-Read size
+	// won't cause DetectContentType to misclassify a real image. Short bodies
+	// (avatars under sniffLen) return ErrUnexpectedEOF — that's expected, we sniff
+	// what we got.
 	buf := make([]byte, sniffLen)
-	n, err := avReader.Read(buf)
-	if err != nil && err != io.EOF {
+	n, err := io.ReadFull(avReader, buf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 		p.Logf("[WARN] can't read from avatar reader for %s, %s", avatarID, err)
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "can't read avatar")
 		return
@@ -224,12 +230,9 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 	etag := `"` + p.Store.ID(avatarID) + `"`
 	w.Header().Set("Etag", etag)
 	w.Header().Set("Cache-Control", "max-age=604800") // 7 days
-	if match := r.Header.Get("If-None-Match"); match != "" {
-		trimmed := strings.TrimPrefix(strings.TrimSuffix(etag, `"`), `"`)
-		if match == trimmed {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
+	if match := r.Header.Get("If-None-Match"); match != "" && etagMatches(match, etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
 	}
 
 	w.Header().Set("Content-Length", strconv.Itoa(size))
@@ -313,19 +316,44 @@ func (p *Proxy) resize(body []byte, limit int) io.Reader {
 }
 
 // safeImgContentType returns the sniffed content type if the bytes look like a safe
-// image format (rasterised: PNG, JPEG, GIF, WebP, BMP, ICO). Returns an error for any
-// non-image content or for image/svg+xml, which can execute scripts when navigated to
-// top-level and must never be served from the avatar origin.
+// raster image format. The set is an explicit allowlist (PNG, JPEG, GIF, WebP, BMP,
+// ICO) — no HasPrefix("image/") catch-all — so future scriptable image/* MIME types
+// added by http.DetectContentType cannot silently pass. Returns an error otherwise.
+// image/svg+xml is excluded because SVG can execute scripts when navigated to top
+// level; image/* coverage of icon files uses both spellings http.DetectContentType
+// is known to return.
 func safeImgContentType(img []byte) (string, error) {
 	ct := http.DetectContentType(img)
 	base := ct
 	if idx := strings.Index(base, ";"); idx >= 0 {
 		base = strings.TrimSpace(base[:idx])
 	}
-	if !strings.HasPrefix(base, "image/") || base == "image/svg+xml" {
-		return "", fmt.Errorf("non-image content type %q", ct)
+	switch base {
+	case "image/png", "image/jpeg", "image/gif", "image/webp", "image/bmp",
+		"image/x-icon", "image/vnd.microsoft.icon":
+		return base, nil
 	}
-	return base, nil
+	return "", fmt.Errorf("non-image content type %q", ct)
+}
+
+// etagMatches reports whether the If-None-Match header value matches the response
+// ETag per RFC 7232: the header is a comma-separated list of opaque-tags (each in
+// double quotes), optionally weak-prefixed with W/. The wildcard "*" matches anything.
+// We deliberately ignore weak/strong distinction because avatar responses are static
+// per id — both forms identify the same resource.
+func etagMatches(header, etag string) bool {
+	header = strings.TrimSpace(header)
+	if header == "*" {
+		return true
+	}
+	for tag := range strings.SplitSeq(header, ",") {
+		tag = strings.TrimSpace(tag)
+		tag = strings.TrimPrefix(tag, "W/")
+		if tag == etag {
+			return true
+		}
+	}
+	return false
 }
 
 // setAvatarDefenseHeaders applies layered defense headers on every avatar response

--- a/avatar/avatar_test.go
+++ b/avatar/avatar_test.go
@@ -2,7 +2,9 @@ package avatar
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"image"
 	"io"
 	"log"
@@ -22,11 +24,13 @@ import (
 )
 
 func TestAvatar_Put(t *testing.T) {
+	pngBytes, err := os.ReadFile("testdata/circles.png")
+	require.NoError(t, err)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/pic.png" {
-			w.Header().Set("Content-Type", "image/*")
-			fmt.Fprint(w, "some picture bin data")
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(pngBytes)
 			return
 		}
 		http.Error(w, "not found", http.StatusNotFound)
@@ -47,7 +51,7 @@ func TestAvatar_Put(t *testing.T) {
 	assert.Equal(t, "http://localhost:8080/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", res)
 	fi, err := os.Stat("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
 	assert.NoError(t, err)
-	assert.Equal(t, int64(21), fi.Size())
+	assert.Equal(t, int64(len(pngBytes)), fi.Size())
 
 	u.ID = "user2"
 	res, err = p.Put(u, client)
@@ -55,18 +59,83 @@ func TestAvatar_Put(t *testing.T) {
 	assert.Equal(t, "http://localhost:8080/avatar/a1881c06eec96db9901c7bbfe41c42a3f08e9cb4.image", res)
 	fi, err = os.Stat("/tmp/avatars.test/84/a1881c06eec96db9901c7bbfe41c42a3f08e9cb4.image")
 	assert.NoError(t, err)
-	assert.Equal(t, int64(21), fi.Size())
+	assert.Equal(t, int64(len(pngBytes)), fi.Size())
+}
+
+// TestAvatar_PutRejectsNonImage proves that an attacker controlling u.Picture cannot
+// poison the avatar store with HTML/SVG/text — Put falls back to an identicon and the
+// stored bytes are guaranteed to be a real PNG, not the attacker payload.
+func TestAvatar_PutRejectsNonImage(t *testing.T) {
+	htmlPayload := []byte("<html><script>alert(document.domain)</script></html>")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png") // lying upstream
+		_, _ = w.Write(htmlPayload)
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	p := Proxy{RoutePath: "/avatar", URL: "http://localhost:8080", Store: NewLocalFS(dir), L: logger.Std}
+
+	u := token.User{ID: "user1", Name: "user1 name", Picture: ts.URL + "/evil.png"}
+	res, err := p.Put(u, &http.Client{Timeout: time.Second})
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8080/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", res)
+
+	stored, err := os.ReadFile(dir + "/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
+	require.NoError(t, err)
+	assert.NotEqual(t, htmlPayload, stored, "attacker payload must not be stored")
+	assert.NotContains(t, string(stored), "<script>", "attacker payload must not be reachable from the store")
+	assert.True(t, bytes.HasPrefix(stored, []byte{0x89, 'P', 'N', 'G'}), "fallback content must be a real PNG (identicon)")
 }
 
 func TestAvatar_PutContent(t *testing.T) {
+	pngBytes, err := os.ReadFile("testdata/circles.png")
+	require.NoError(t, err)
+
 	defer func() { _ = os.RemoveAll("/tmp/avatars.put-content.test/") }()
 	p := Proxy{RoutePath: "/avatar", URL: "http://localhost:8080", Store: NewLocalFS("/tmp/avatars.put-content.test"), L: logger.Std}
-	got, err := p.PutContent("user1", strings.NewReader("png-bytes"))
+	got, err := p.PutContent("user1", bytes.NewReader(pngBytes))
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:8080/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", got)
 	fi, err := os.Stat("/tmp/avatars.put-content.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
 	require.NoError(t, err)
 	assert.Greater(t, fi.Size(), int64(0))
+
+	// non-image bytes are rejected — never stored
+	_, err = p.PutContent("attacker", strings.NewReader("<html><script>alert(1)</script></html>"))
+	require.Error(t, err, "non-image content must be rejected at PutContent")
+	assert.Contains(t, err.Error(), "not a valid image")
+}
+
+// TestAvatar_HandlerRejectsPoisonedStore proves that even if the store contains
+// attacker-controlled non-image bytes (e.g. poisoned before the fix), Handler refuses
+// to serve them and returns 415 with strict defense headers instead.
+func TestAvatar_HandlerRejectsPoisonedStore(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalFS(dir)
+
+	// directly seed the store with an HTML payload at user1's avatar id
+	htmlPayload := []byte("<html><body><script>alert(document.domain)</script></body></html>")
+	_, err := store.Put("user1", bytes.NewReader(htmlPayload))
+	require.NoError(t, err)
+
+	p := Proxy{RoutePath: "/avatar", URL: "http://localhost:8080", Store: store, L: logger.Std}
+
+	req := httptest.NewRequest("GET", "/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", http.NoBody)
+	rr := httptest.NewRecorder()
+	p.Handler(rr, req)
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, rr.Code, "poisoned store bytes must be rejected at serve time")
+	assert.False(t, strings.HasPrefix(rr.Header().Get("Content-Type"), "text/html"),
+		"reject response must not be text/html (got %q)", rr.Header().Get("Content-Type"))
+	assert.NotContains(t, rr.Body.String(), "<script>", "attacker payload must never appear in response body")
+	// defense headers on the rejection path too
+	assert.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+	assert.Contains(t, rr.Header().Get("Content-Disposition"), "inline")
+	csp := rr.Header().Get("Content-Security-Policy")
+	assert.Contains(t, csp, "default-src 'none'")
+	assert.Contains(t, csp, "sandbox")
 }
 
 func TestAvatar_RedactAvatarURL(t *testing.T) {
@@ -132,8 +201,6 @@ func TestAvatar_PutFailed(t *testing.T) {
 }
 
 func TestAvatar_PutCapsBodySize(t *testing.T) {
-	// upstream that streams indefinitely past the cap; without
-	// the maxAvatarFetchSize check resize would consume all bytes.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "image/*")
 		w.WriteHeader(http.StatusOK)
@@ -157,13 +224,15 @@ func TestAvatar_PutCapsBodySize(t *testing.T) {
 }
 
 func TestAvatar_Routes(t *testing.T) {
+	pngBytes, err := os.ReadFile("testdata/circles.png")
+	require.NoError(t, err)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/pic.png" {
-			w.Header().Set("Content-Type", "image/jpg")
+			w.Header().Set("Content-Type", "image/jpg") // intentionally wrong upstream CT — proxy must ignore it
 			w.Header().Set("Custom-Header", "xyz")
-			_, err := fmt.Fprint(w, "some picture bin data")
-			require.NoError(t, err)
+			_, wrErr := w.Write(pngBytes)
+			require.NoError(t, wrErr)
 			return
 		}
 		http.Error(w, "not found", http.StatusNotFound)
@@ -176,7 +245,7 @@ func TestAvatar_Routes(t *testing.T) {
 	client := &http.Client{Timeout: time.Second}
 
 	u := token.User{ID: "user1", Name: "user1 name", Picture: ts.URL + "/pic.png"}
-	_, err := p.Put(u, client)
+	_, err = p.Put(u, client)
 	assert.NoError(t, err)
 
 	{
@@ -199,7 +268,7 @@ func TestAvatar_Routes(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, rr.Code)
 	}
 
-	{ // status 200
+	{ // status 200 — real PNG bytes round-trip and are served as image/png (upstream lied with image/jpg)
 		req, e := http.NewRequest("GET", "/b3daa77b4c04a9551b8781d03191fe098f325e67.image", http.NoBody)
 		require.NoError(t, e)
 		rr := httptest.NewRecorder()
@@ -207,16 +276,22 @@ func TestAvatar_Routes(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, []string{"image/*"}, rr.Header()["Content-Type"])
-		assert.Equal(t, []string{"21"}, rr.Header()["Content-Length"])
+		assert.Equal(t, "image/png", rr.Header().Get("Content-Type"), "must sniff actual bytes, not trust upstream image/jpg")
+		assert.Equal(t, strconv.Itoa(len(pngBytes)), rr.Header().Get("Content-Length"))
 		assert.Equal(t, []string(nil), rr.Header()["Custom-Header"], "strip all custom headers")
 		assert.NotNil(t, rr.Header()["Etag"])
+		// defense headers must be present on every response
+		assert.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+		assert.Contains(t, rr.Header().Get("Content-Disposition"), "inline")
+		csp := rr.Header().Get("Content-Security-Policy")
+		assert.Contains(t, csp, "default-src 'none'")
+		assert.Contains(t, csp, "sandbox")
 
 		bb := bytes.Buffer{}
 		sz, e := io.Copy(&bb, rr.Body)
 		assert.NoError(t, e)
-		assert.Equal(t, int64(21), sz)
-		assert.Equal(t, "some picture bin data", bb.String())
+		assert.Equal(t, int64(len(pngBytes)), sz)
+		assert.Equal(t, pngBytes, bb.Bytes())
 	}
 
 	{
@@ -309,15 +384,15 @@ func TestAvatar_resize(t *testing.T) {
 	resizedR := p.resize(nil, 100)
 	assert.Nil(t, resizedR)
 
-	// negative limit error.
-	resizedR = p.resize(strings.NewReader("some picture bin data"), -1)
-	require.NotNil(t, resizedR)
-	checkC(t, resizedR, []byte("some picture bin data"))
-
-	// decode error.
-	resizedR = p.resize(strings.NewReader("invalid image content"), 100)
-	assert.NotNil(t, resizedR)
-	checkC(t, resizedR, []byte("invalid image content"))
+	// non-image bytes (e.g. an attacker's HTML payload) must NEVER pass through, even
+	// with limit <= 0: returning the raw bytes would let storage be poisoned with
+	// arbitrary content that Handler() would later sniff and serve as text/html.
+	assert.Nil(t, p.resize(strings.NewReader("some picture bin data"), -1),
+		"non-image must be rejected regardless of limit (no pass-through)")
+	assert.Nil(t, p.resize(strings.NewReader("invalid image content"), 100),
+		"decode failure must return nil (no pass-through)")
+	assert.Nil(t, p.resize(strings.NewReader("<html><script>alert(1)</script></html>"), 100),
+		"HTML body must be rejected")
 
 	cases := []struct {
 		file   string
@@ -336,6 +411,13 @@ func TestAvatar_resize(t *testing.T) {
 		assert.NotNil(t, resizedR, "file %s", c.file)
 		checkC(t, resizedR, img)
 
+		// no-resize path with limit=0 must also preserve the original bytes verbatim —
+		// this matters for animated GIFs and other multi-frame formats where decoding
+		// via image.Decode would consume only the first frame and truncate the rest.
+		resizedR = p.resize(bytes.NewReader(img), 0)
+		assert.NotNil(t, resizedR, "limit=0 must return original bytes for %s", c.file)
+		checkC(t, resizedR, img)
+
 		// resizing to half of width. Check resizedR avatar format PNG.
 		resizedR = p.resize(bytes.NewReader(img), 400)
 		assert.NotNil(t, resizedR, "file %s", c.file)
@@ -347,6 +429,62 @@ func TestAvatar_resize(t *testing.T) {
 		assert.Equal(t, c.wr, bounds.Dx(), "file %s", c.file)
 		assert.Equal(t, c.hr, bounds.Dy(), "file %s", c.file)
 	}
+}
+
+// TestAvatar_resizeRejectsDecompressionBomb proves a tiny PNG that declares huge
+// dimensions in its IHDR chunk is rejected via DecodeConfig (cheap, no allocation)
+// before image.Decode is called. Without this check, image.Decode would allocate
+// width*height*4 bytes of pixel memory and OOM the auth service on each login that
+// fetches an attacker-controlled u.Picture.
+//
+// The product-overflow case (65535×65535 wraps int32) is also exercised: the guard
+// must compute the product in int64 so 32-bit builds (GOARCH=386, 32-bit arm) cannot
+// be tricked into letting the bomb through by integer wraparound.
+func TestAvatar_resizeRejectsDecompressionBomb(t *testing.T) {
+	cases := []struct {
+		name   string
+		w, h   uint32
+		reason string
+	}{
+		{name: "huge square", w: 65535, h: 65535, reason: "well over maxAvatarPixels; also overflows int32 product"},
+		{name: "non-square overflow", w: 70000, h: 70000, reason: "still overflows int32 product on 32-bit builds"},
+		{name: "thin huge area", w: 1 << 24, h: 1 << 24, reason: "product fits int64 but exceeds maxAvatarPixels by orders of magnitude"},
+	}
+	p := Proxy{L: logger.Std}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bomb := makeBombPNG(c.w, c.h)
+			require.Less(t, len(bomb), 100, "bomb must be small compressed — that is the threat model")
+			assert.Nil(t, p.resize(bytes.NewReader(bomb), 100), "limit>0: %s", c.reason)
+			assert.Nil(t, p.resize(bytes.NewReader(bomb), 0), "limit=0: %s", c.reason)
+		})
+	}
+}
+
+// makeBombPNG constructs a PNG header with an IHDR chunk declaring the given
+// width/height but no IDAT body. image.DecodeConfig returns those dimensions
+// without allocating pixel memory; image.Decode on the same bytes would either
+// fail or attempt to allocate w*h*4 bytes.
+func makeBombPNG(width, height uint32) []byte {
+	var buf bytes.Buffer
+	buf.Write([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'})
+
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], width)
+	binary.BigEndian.PutUint32(ihdr[4:8], height)
+	ihdr[8] = 8  // bit depth
+	ihdr[9] = 2  // RGB color type
+	ihdr[10] = 0 // compression
+	ihdr[11] = 0 // filter
+	ihdr[12] = 0 // interlace
+
+	_ = binary.Write(&buf, binary.BigEndian, uint32(13)) // chunk length
+	buf.WriteString("IHDR")
+	buf.Write(ihdr)
+
+	crcInput := append([]byte("IHDR"), ihdr...)
+	_ = binary.Write(&buf, binary.BigEndian, crc32.ChecksumIEEE(crcInput))
+	return buf.Bytes()
 }
 
 func TestAvatar_GetGravatarURL(t *testing.T) {

--- a/avatar/avatar_test.go
+++ b/avatar/avatar_test.go
@@ -2,6 +2,7 @@ package avatar
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
@@ -22,6 +23,20 @@ import (
 	"github.com/go-pkgz/auth/logger"
 	"github.com/go-pkgz/auth/token"
 )
+
+// tinyWebP is the smallest valid WebP (VP8 lossy 1x1). Used to regression-test
+// that Proxy.resize accepts WebP, which Go's stdlib image package does not register
+// by default — only the side-effect import of golang.org/x/image/webp in avatar.go
+// makes this work.
+var tinyWebP = mustDecodeBase64("UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/vshDgA=")
+
+func mustDecodeBase64(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic("test fixture: invalid base64: " + err.Error())
+	}
+	return b
+}
 
 func TestAvatar_Put(t *testing.T) {
 	pngBytes, err := os.ReadFile("testdata/circles.png")
@@ -295,18 +310,31 @@ func TestAvatar_Routes(t *testing.T) {
 	}
 
 	{
-		// status 304
+		// status 304 — client sends the same quoted ETag back, per RFC 7232
 		req, e := http.NewRequest("GET", "/b3daa77b4c04a9551b8781d03191fe098f325e67.image", http.NoBody)
 		require.NoError(t, e)
 		id := p.Store.ID("b3daa77b4c04a9551b8781d03191fe098f325e67.image")
-		req.Header.Add("If-None-Match", p.Store.ID(id)) // hash of `some_random_name.image` since the file doesn't exist
+		req.Header.Set("If-None-Match", `"`+id+`"`)
 
 		rr := httptest.NewRecorder()
 		handler := http.Handler(http.HandlerFunc(p.Handler))
 		handler.ServeHTTP(rr, req)
 
-		assert.Equal(t, http.StatusNotModified, rr.Code)
+		assert.Equal(t, http.StatusNotModified, rr.Code, "quoted If-None-Match matching the response ETag must 304")
 		assert.Equal(t, []string{`"` + id + `"`}, rr.Header()["Etag"])
+	}
+
+	{
+		// status 304 — weak validator form W/"..." also matches
+		req, e := http.NewRequest("GET", "/b3daa77b4c04a9551b8781d03191fe098f325e67.image", http.NoBody)
+		require.NoError(t, e)
+		id := p.Store.ID("b3daa77b4c04a9551b8781d03191fe098f325e67.image")
+		req.Header.Set("If-None-Match", `W/"`+id+`"`)
+
+		rr := httptest.NewRecorder()
+		handler := http.Handler(http.HandlerFunc(p.Handler))
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotModified, rr.Code, "weak If-None-Match must also 304")
 	}
 }
 
@@ -485,6 +513,51 @@ func makeBombPNG(width, height uint32) []byte {
 	crcInput := append([]byte("IHDR"), ihdr...)
 	_ = binary.Write(&buf, binary.BigEndian, crc32.ChecksumIEEE(crcInput))
 	return buf.Bytes()
+}
+
+// TestAvatar_resizeAcceptsWebP regression-checks Discord-style WebP avatars. Go's
+// stdlib image package only registers PNG/JPEG/GIF decoders; without the side-effect
+// import of golang.org/x/image/webp in avatar.go, image.DecodeConfig would fail on
+// WebP and Discord users would silently get an identicon instead of their real avatar.
+func TestAvatar_resizeAcceptsWebP(t *testing.T) {
+	p := Proxy{L: logger.Std}
+	got := p.resize(tinyWebP, 0)
+	require.NotNil(t, got, "WebP avatar must be accepted by resize when limit=0")
+	out, err := io.ReadAll(got)
+	require.NoError(t, err)
+	assert.Equal(t, tinyWebP, out, "no-resize path must return WebP bytes verbatim")
+
+	// safeImgContentType must also agree
+	ct, err := safeImgContentType(tinyWebP)
+	require.NoError(t, err)
+	assert.Equal(t, "image/webp", ct)
+}
+
+// TestEtagMatches covers the If-None-Match parsing per RFC 7232 — quoted, weak,
+// comma-separated, and wildcard forms. The handler previously compared against
+// an unquoted etag while browsers send the quoted form, so 304 short-circuits
+// never fired.
+func TestEtagMatches(t *testing.T) {
+	const etag = `"abc123"`
+	tbl := []struct {
+		header string
+		want   bool
+	}{
+		{etag, true},                   // exact match — what browsers send
+		{`W/"abc123"`, true},            // weak validator
+		{`"other", "abc123"`, true},     // comma-separated, second matches
+		{` "abc123" `, true},            // leading/trailing whitespace
+		{`*`, true},                     // wildcard matches anything
+		{`"abc"`, false},                // different etag
+		{`"abc123x"`, false},            // substring shouldn't match
+		{``, false},                     // empty
+		{`abc123`, false},               // unquoted — invalid per RFC, must not match
+	}
+	for _, tt := range tbl {
+		t.Run(tt.header, func(t *testing.T) {
+			assert.Equal(t, tt.want, etagMatches(tt.header, etag))
+		})
+	}
 }
 
 func TestAvatar_GetGravatarURL(t *testing.T) {

--- a/avatar/avatar_test.go
+++ b/avatar/avatar_test.go
@@ -387,11 +387,11 @@ func TestAvatar_resize(t *testing.T) {
 	// non-image bytes (e.g. an attacker's HTML payload) must NEVER pass through, even
 	// with limit <= 0: returning the raw bytes would let storage be poisoned with
 	// arbitrary content that Handler() would later sniff and serve as text/html.
-	assert.Nil(t, p.resize(strings.NewReader("some picture bin data"), -1),
+	assert.Nil(t, p.resize([]byte("some picture bin data"), -1),
 		"non-image must be rejected regardless of limit (no pass-through)")
-	assert.Nil(t, p.resize(strings.NewReader("invalid image content"), 100),
+	assert.Nil(t, p.resize([]byte("invalid image content"), 100),
 		"decode failure must return nil (no pass-through)")
-	assert.Nil(t, p.resize(strings.NewReader("<html><script>alert(1)</script></html>"), 100),
+	assert.Nil(t, p.resize([]byte("<html><script>alert(1)</script></html>"), 100),
 		"HTML body must be rejected")
 
 	cases := []struct {
@@ -407,19 +407,19 @@ func TestAvatar_resize(t *testing.T) {
 		require.Nil(t, err, "can't open test file %s", c.file)
 
 		// no need for resize, avatar dimensions are smaller than resize limit.
-		resizedR = p.resize(bytes.NewReader(img), 800)
+		resizedR = p.resize(img, 800)
 		assert.NotNil(t, resizedR, "file %s", c.file)
 		checkC(t, resizedR, img)
 
 		// no-resize path with limit=0 must also preserve the original bytes verbatim —
 		// this matters for animated GIFs and other multi-frame formats where decoding
 		// via image.Decode would consume only the first frame and truncate the rest.
-		resizedR = p.resize(bytes.NewReader(img), 0)
+		resizedR = p.resize(img, 0)
 		assert.NotNil(t, resizedR, "limit=0 must return original bytes for %s", c.file)
 		checkC(t, resizedR, img)
 
 		// resizing to half of width. Check resizedR avatar format PNG.
-		resizedR = p.resize(bytes.NewReader(img), 400)
+		resizedR = p.resize(img, 400)
 		assert.NotNil(t, resizedR, "file %s", c.file)
 
 		imgRz, format, err := image.Decode(resizedR)
@@ -455,8 +455,8 @@ func TestAvatar_resizeRejectsDecompressionBomb(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			bomb := makeBombPNG(c.w, c.h)
 			require.Less(t, len(bomb), 100, "bomb must be small compressed — that is the threat model")
-			assert.Nil(t, p.resize(bytes.NewReader(bomb), 100), "limit>0: %s", c.reason)
-			assert.Nil(t, p.resize(bytes.NewReader(bomb), 0), "limit=0: %s", c.reason)
+			assert.Nil(t, p.resize(bomb, 100), "limit>0: %s", c.reason)
+			assert.Nil(t, p.resize(bomb, 0), "limit=0: %s", c.reason)
 		})
 	}
 }

--- a/provider/telegram_test.go
+++ b/provider/telegram_test.go
@@ -30,8 +30,16 @@ var botInfoFunc = func(ctx context.Context) (*botInfo, error) {
 // tinyPNG is the smallest valid PNG (1x1 transparent). Tests that exercise the
 // avatar.Proxy.PutContent path need bytes that pass image.Decode; raw "png-bytes"
 // would be rejected by Proxy.resize after the content-type-spoof XSS fix.
-var tinyPNG, _ = base64.StdEncoding.DecodeString(
+var tinyPNG = mustDecodeBase64(
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==")
+
+func mustDecodeBase64(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic("test fixture: invalid base64: " + err.Error())
+	}
+	return b
+}
 
 func TestTgLoginHandlerErrors(t *testing.T) {
 	tg := TelegramHandler{Telegram: NewTelegramAPI("test", http.DefaultClient)}
@@ -366,7 +374,9 @@ func (legacyAvatarSaver) Put(authtoken.User, *http.Client) (string, error) { ret
 type failingAvatarSaver struct{}
 
 func (failingAvatarSaver) Put(authtoken.User, *http.Client) (string, error) { return "", nil }
-func (failingAvatarSaver) PutContent(string, io.Reader) (string, error)     { return "", fmt.Errorf("disk full") }
+func (failingAvatarSaver) PutContent(string, io.Reader) (string, error) {
+	return "", fmt.Errorf("disk full")
+}
 
 func TestSaveTelegramAvatar_TypedNilAvatarSaverDoesNotPanic(t *testing.T) {
 	avatarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -414,7 +424,7 @@ func TestTelegramLoginHandler_DoesNotOverwriteSavedAvatar(t *testing.T) {
 	}
 
 	updates := &telegramUpdate{}
-	require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(getUpdatesResp, tok)), updates))
+	require.NoError(t, json.Unmarshal(fmt.Appendf(nil, getUpdatesResp, tok), updates))
 	th.processUpdates(context.Background(), updates)
 
 	got := th.requests.data[tok]

--- a/provider/telegram_test.go
+++ b/provider/telegram_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,6 +26,12 @@ import (
 var botInfoFunc = func(ctx context.Context) (*botInfo, error) {
 	return &botInfo{Username: "my_auth_bot"}, nil
 }
+
+// tinyPNG is the smallest valid PNG (1x1 transparent). Tests that exercise the
+// avatar.Proxy.PutContent path need bytes that pass image.Decode; raw "png-bytes"
+// would be rejected by Proxy.resize after the content-type-spoof XSS fix.
+var tinyPNG, _ = base64.StdEncoding.DecodeString(
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==")
 
 func TestTgLoginHandlerErrors(t *testing.T) {
 	tg := TelegramHandler{Telegram: NewTelegramAPI("test", http.DefaultClient)}
@@ -138,12 +145,8 @@ func TestTelegramConfirmedRequest(t *testing.T) {
 		BotInfoFunc: botInfoFunc,
 	}
 
-	// stand up a tiny server that serves the avatar bytes — the
-	// saveTelegramAvatar helper does an HTTP GET on whatever URL Avatar
-	// returns; using a real, reachable URL keeps the bot-token redaction
-	// logic exercised end-to-end.
 	avatarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("png-bytes"))
+		_, _ = w.Write(tinyPNG)
 	}))
 	defer avatarSrv.Close()
 	m.AvatarFunc = func(ctx context.Context, userID int) (string, error) {
@@ -252,8 +255,6 @@ func TestSaveTelegramAvatar_TransportErrorDoesNotLeakBotToken(t *testing.T) {
 		AvatarSaver: &mockAvatarSaver{},
 		L:           captureLog,
 	}
-	// unreachable host -- forces http.Client.Do to return a *url.Error whose
-	// default stringification embeds the full URL (including bot token).
 	got := th.saveTelegramAvatar(context.Background(), "user1",
 		"https://api.telegram.invalid/file/bot"+botToken+"/photo.jpg")
 	assert.Equal(t, "", got)
@@ -355,53 +356,33 @@ func TestSaveTelegramAvatar_BotTokenNeverLogged(t *testing.T) {
 	})
 }
 
+type legacyAvatarSaver struct{}
+
+func (legacyAvatarSaver) Put(authtoken.User, *http.Client) (string, error) { return "", nil }
+
 // failingAvatarSaver implements both Put and PutContent but its PutContent
 // returns an error -- exercises the saver-side failure branch in
 // saveTelegramAvatar without going through a real avatar.Proxy.
 type failingAvatarSaver struct{}
 
-func (failingAvatarSaver) Put(authtoken.User, *http.Client) (string, error)    { return "", nil }
-func (failingAvatarSaver) PutContent(string, io.Reader) (string, error)        { return "", fmt.Errorf("disk full") }
+func (failingAvatarSaver) Put(authtoken.User, *http.Client) (string, error) { return "", nil }
+func (failingAvatarSaver) PutContent(string, io.Reader) (string, error)     { return "", fmt.Errorf("disk full") }
 
-type legacyAvatarSaver struct{}
-
-func (legacyAvatarSaver) Put(authtoken.User, *http.Client) (string, error) { return "", nil }
-
-// TestSaveTelegramAvatar_TypedNilAvatarSaverDoesNotPanic guards against the
-// case where Opts.AvatarStore is unset. auth.go skips initializing
-// res.avatarProxy then, so AvatarSaver ends up as a typed-nil *avatar.Proxy
-// (non-nil interface wrapping a nil pointer). The avatarContentSaver type
-// assertion would still succeed because interface satisfaction is structural,
-// and PutContent on a nil receiver would panic on the first p.Store deref.
-// The guard returns "" with a warn log instead.
 func TestSaveTelegramAvatar_TypedNilAvatarSaverDoesNotPanic(t *testing.T) {
 	avatarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("png-bytes"))
+		_, _ = w.Write(tinyPNG)
 	}))
 	defer avatarSrv.Close()
 
 	var nilProxy *avatar.Proxy
 	th := &TelegramHandler{AvatarSaver: nilProxy, L: logger.NoOp}
-	// reachable URL so that without the typed-nil guard the function would
-	// proceed past the fetch into PutContent on a nil receiver and panic
-	// inside avatar.Proxy at p.Store deref.
 	got := th.saveTelegramAvatar(context.Background(), "user1", avatarSrv.URL+"/file/botSECRET/photo.jpg")
 	assert.Equal(t, "", got, "typed-nil AvatarSaver must short-circuit before fetch + PutContent")
 }
 
-// TestTelegramLoginHandler_DoesNotOverwriteSavedAvatar guards against the
-// double-pipeline regression: after saveTelegramAvatar stores the bytes and
-// sets Picture to a local proxy URL, LoginHandler used to call setAvatar
-// which re-fetches Picture. In split-DNS / unreachable-internal-Opts.URL
-// deployments the fetch fails and Proxy.Put silently overwrites the just-
-// stored Telegram avatar with an identicon at the same store path. This
-// test wires a real avatar.Proxy with an unreachable Opts.URL and asserts
-// the second-pass fetch does not happen (Picture survives intact).
 func TestTelegramLoginHandler_DoesNotOverwriteSavedAvatar(t *testing.T) {
 	dir := t.TempDir()
 	store := avatar.NewLocalFS(dir)
-	// unreachable URL so any Proxy.Put re-fetch would fail and trigger
-	// identicon fallback at the same store path
 	proxy := &avatar.Proxy{
 		Store:     store,
 		URL:       "http://127.0.0.1:1",
@@ -410,7 +391,7 @@ func TestTelegramLoginHandler_DoesNotOverwriteSavedAvatar(t *testing.T) {
 	}
 
 	avatarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("png-bytes"))
+		_, _ = w.Write(tinyPNG)
 	}))
 	defer avatarSrv.Close()
 
@@ -460,11 +441,6 @@ func TestTelegramLoginHandler_DoesNotOverwriteSavedAvatar(t *testing.T) {
 // a TelegramAPI mock that hands back a URL containing a bot-token-like marker,
 // then asserts (a) the marker never lands in authRequest.user.Picture and
 // (b) the marker never appears in any captured log line.
-//
-// Reverting the saveTelegramAvatar redirection (i.e. assigning avatarURL
-// directly to user.Picture) makes assertion (a) fail. Reverting the avatar
-// proxy log redaction makes assertion (b) fail when the avatar pipeline
-// actually fetches the URL. Either way the test will scream loudly.
 func TestTelegramProcessUpdates_BotTokenNeverInUserPicture(t *testing.T) {
 	const botToken = "secret-bot-token-marker"
 	var logBuf strings.Builder

--- a/provider/verify_test.go
+++ b/provider/verify_test.go
@@ -293,7 +293,7 @@ func TestInMemoryVerifStore(t *testing.T) {
 		successes := int32(0)
 		errs := int32(0)
 		wg.Add(goroutines)
-		for i := 0; i < goroutines; i++ {
+		for range goroutines {
 			go func() {
 				defer wg.Done()
 				used, err := s.MarkUsed("hot-key", time.Hour)
@@ -318,7 +318,7 @@ func TestInMemoryVerifStore(t *testing.T) {
 		s := NewInMemoryVerifStore().(*inMemoryVerifStore)
 		// 3 inserts with nanosecond TTL — quickly expire, no sweep yet
 		// (insertCount=3 < 4)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			used, err := s.MarkUsed(fmt.Sprintf("expired-%d", i), time.Nanosecond)
 			require.NoError(t, err)
 			require.False(t, used)

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -237,7 +237,30 @@ func (s *Service) Handlers() (authHandler, avatarHandler http.Handler) {
 		p.Handler(w, r)
 	}
 
-	return http.HandlerFunc(ah), http.HandlerFunc(s.avatarProxy.Handler)
+	return withSecurityHeaders(http.HandlerFunc(ah)), withSecurityHeaders(http.HandlerFunc(s.avatarProxy.Handler))
+}
+
+// withSecurityHeaders wraps an auth response handler to apply strict CSP and nosniff
+// on every response. The go-pkgz/auth package response surface is JSON-only for auth
+// routes and images for the avatar route — no consumer-customisable HTML anywhere —
+// so this CSP is unconditionally safe and gives the auth origin defense-in-depth
+// against any future trust-boundary regression that might emit a renderable body.
+//
+//   - Content-Security-Policy: default-src 'none'; sandbox — blocks inline scripts
+//     and event handlers even if a body is ever served as HTML by mistake; the
+//     sandbox directive additionally isolates any rendered document from this origin.
+//   - X-Content-Type-Options: nosniff — prevents browsers from MIME-overriding the
+//     declared Content-Type to a more dangerous one.
+//
+// The avatar Handler additionally sets Content-Disposition: inline; filename="avatar"
+// inside itself, so direct callers (tests, custom mounts) still get the full header
+// set without going through this wrapper.
+func withSecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox; frame-ancestors 'none'")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Middleware returns auth middleware

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -241,10 +241,11 @@ func (s *Service) Handlers() (authHandler, avatarHandler http.Handler) {
 }
 
 // withSecurityHeaders wraps an auth response handler to apply strict CSP and nosniff
-// on every response. The go-pkgz/auth package response surface is JSON-only for auth
-// routes and images for the avatar route — no consumer-customisable HTML anywhere —
-// so this CSP is unconditionally safe and gives the auth origin defense-in-depth
-// against any future trust-boundary regression that might emit a renderable body.
+// on every response. The go-pkgz/auth package's own response surface is JSON-only
+// for auth routes and images for the avatar route — no built-in HTML rendering
+// anywhere — so this CSP is unconditionally safe and gives the auth origin
+// defense-in-depth against any future trust-boundary regression that might emit a
+// renderable body.
 //
 //   - Content-Security-Policy: default-src 'none'; sandbox — blocks inline scripts
 //     and event handlers even if a body is ever served as HTML by mistake; the
@@ -255,6 +256,14 @@ func (s *Service) Handlers() (authHandler, avatarHandler http.Handler) {
 // The avatar Handler additionally sets Content-Disposition: inline; filename="avatar"
 // inside itself, so direct callers (tests, custom mounts) still get the full header
 // set without going through this wrapper.
+//
+// CONSUMER NOTE: custom providers added via Service.AddCustomHandler / AddProvider
+// are also wrapped. If a custom provider renders HTML (login forms, JS-based flows,
+// the dev_provider's login page, etc.), the strict CSP will block inline scripts and
+// event handlers on those pages. Such providers should either (a) override the CSP
+// for their own response by calling w.Header().Set("Content-Security-Policy", ...)
+// before writing — Set replaces the wrapper's value — or (b) move any required
+// scripts/styles to external files served from 'self'.
 func withSecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox; frame-ancestors 'none'")

--- a/v2/auth_test.go
+++ b/v2/auth_test.go
@@ -432,6 +432,42 @@ func TestLogoutNoProviders(t *testing.T) {
 	assert.Equal(t, "{\"error\":\"providers not defined\"}\n", string(b))
 }
 
+// TestHandlers_SecurityHeaders proves the mandatory CSP + nosniff wrapper is applied
+// to every response returned by Service.Handlers(), regardless of route or status.
+// go-pkgz/auth has no customisable HTML rendering, so this CSP is unconditionally safe.
+func TestHandlers_SecurityHeaders(t *testing.T) {
+	svc := NewService(Opts{Logger: logger.Std})
+	authRoute, avatarRoute := svc.Handlers()
+
+	mux := http.NewServeMux()
+	mux.Handle("/auth/", authRoute)
+	mux.Handle("/avatar/", avatarRoute)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	// avatar handler verified separately in avatar_test.go; here we just need to
+	// confirm the wrapper applies across the auth route group.
+	probes := []string{
+		"/auth/list",      // 200 JSON
+		"/auth/logout",    // 400 JSON (no providers configured)
+		"/auth/user",      // 401 JSON (no jwt)
+		"/auth/status",    // 200 JSON
+		"/auth/bad/login", // 400 JSON
+	}
+	for _, path := range probes {
+		t.Run(path, func(t *testing.T) {
+			resp, err := http.Get(ts.URL + path)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			csp := resp.Header.Get("Content-Security-Policy")
+			assert.Contains(t, csp, "default-src 'none'", "missing strict CSP on %s (status=%d)", path, resp.StatusCode)
+			assert.Contains(t, csp, "sandbox", "missing sandbox directive on %s", path)
+			assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"),
+				"missing nosniff on %s", path)
+		})
+	}
+}
+
 func TestBadRequests(t *testing.T) {
 	_, teardown := prepService(t)
 	defer teardown()

--- a/v2/avatar/avatar.go
+++ b/v2/avatar/avatar.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-pkgz/rest"
 	"github.com/rrivera/identicon"
 	"golang.org/x/image/draw"
+	_ "golang.org/x/image/webp" // register WebP decoder so Discord-style .webp avatars validate
 
 	"github.com/go-pkgz/auth/v2/logger"
 	"github.com/go-pkgz/auth/v2/token"
@@ -194,9 +195,14 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	// io.ReadFull keeps reading until the buffer is full or EOF, so a Store
+	// implementation that returns a buffered reader with a small first-Read size
+	// won't cause DetectContentType to misclassify a real image. Short bodies
+	// (avatars under sniffLen) return ErrUnexpectedEOF — that's expected, we sniff
+	// what we got.
 	buf := make([]byte, sniffLen)
-	n, err := avReader.Read(buf)
-	if err != nil && err != io.EOF {
+	n, err := io.ReadFull(avReader, buf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 		p.Logf("[WARN] can't read from avatar reader for %s, %s", avatarID, err)
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "can't read avatar")
 		return
@@ -224,12 +230,9 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 	etag := `"` + p.Store.ID(avatarID) + `"`
 	w.Header().Set("Etag", etag)
 	w.Header().Set("Cache-Control", "max-age=604800") // 7 days
-	if match := r.Header.Get("If-None-Match"); match != "" {
-		trimmed := strings.TrimPrefix(strings.TrimSuffix(etag, `"`), `"`)
-		if match == trimmed {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
+	if match := r.Header.Get("If-None-Match"); match != "" && etagMatches(match, etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
 	}
 
 	w.Header().Set("Content-Length", strconv.Itoa(size))
@@ -313,19 +316,44 @@ func (p *Proxy) resize(body []byte, limit int) io.Reader {
 }
 
 // safeImgContentType returns the sniffed content type if the bytes look like a safe
-// image format (rasterised: PNG, JPEG, GIF, WebP, BMP, ICO). Returns an error for any
-// non-image content or for image/svg+xml, which can execute scripts when navigated to
-// top-level and must never be served from the avatar origin.
+// raster image format. The set is an explicit allowlist (PNG, JPEG, GIF, WebP, BMP,
+// ICO) — no HasPrefix("image/") catch-all — so future scriptable image/* MIME types
+// added by http.DetectContentType cannot silently pass. Returns an error otherwise.
+// image/svg+xml is excluded because SVG can execute scripts when navigated to top
+// level; image/* coverage of icon files uses both spellings http.DetectContentType
+// is known to return.
 func safeImgContentType(img []byte) (string, error) {
 	ct := http.DetectContentType(img)
 	base := ct
 	if idx := strings.Index(base, ";"); idx >= 0 {
 		base = strings.TrimSpace(base[:idx])
 	}
-	if !strings.HasPrefix(base, "image/") || base == "image/svg+xml" {
-		return "", fmt.Errorf("non-image content type %q", ct)
+	switch base {
+	case "image/png", "image/jpeg", "image/gif", "image/webp", "image/bmp",
+		"image/x-icon", "image/vnd.microsoft.icon":
+		return base, nil
 	}
-	return base, nil
+	return "", fmt.Errorf("non-image content type %q", ct)
+}
+
+// etagMatches reports whether the If-None-Match header value matches the response
+// ETag per RFC 7232: the header is a comma-separated list of opaque-tags (each in
+// double quotes), optionally weak-prefixed with W/. The wildcard "*" matches anything.
+// We deliberately ignore weak/strong distinction because avatar responses are static
+// per id — both forms identify the same resource.
+func etagMatches(header, etag string) bool {
+	header = strings.TrimSpace(header)
+	if header == "*" {
+		return true
+	}
+	for tag := range strings.SplitSeq(header, ",") {
+		tag = strings.TrimSpace(tag)
+		tag = strings.TrimPrefix(tag, "W/")
+		if tag == etag {
+			return true
+		}
+	}
+	return false
 }
 
 // setAvatarDefenseHeaders applies layered defense headers on every avatar response

--- a/v2/avatar/avatar.go
+++ b/v2/avatar/avatar.go
@@ -59,7 +59,7 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 			return "", fmt.Errorf("no picture for %s: %w", userID, e)
 		}
 		// put returns avatar base name, like 123456.image
-		avatarID, e := p.Store.Put(userID, p.resize(bytes.NewBuffer(b), p.ResizeLimit))
+		avatarID, e := p.Store.Put(userID, p.resize(b, p.ResizeLimit))
 		if e != nil {
 			return "", e
 		}
@@ -78,12 +78,6 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 		p.Logf("[DEBUG] failed to fetch avatar from the orig %s, %v", redactAvatarURL(u.Picture), err)
 		return genIdenticon(u.ID)
 	}
-
-	defer func() {
-		if e := body.Close(); e != nil {
-			p.Logf("[WARN] can't close response body, %s", e)
-		}
-	}()
 
 	resized := p.resize(body, p.ResizeLimit)
 	if resized == nil {
@@ -107,8 +101,18 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 // in the upstream URL (e.g. Telegram bot file API: /file/bot{TOKEN}/...) can fetch the
 // content themselves and avoid exposing the credential to Put's URL-fetching path —
 // where it would land in u.Picture, debug logs, and the user JSON returned to clients.
+//
+// Bytes are read into memory bounded by maxAvatarFetchSize so an unbounded caller
+// (e.g. a streaming HTTP body) cannot exhaust process memory.
 func (p *Proxy) PutContent(userID string, content io.Reader) (avatarURL string, err error) {
-	resized := p.resize(content, p.ResizeLimit)
+	body, err := io.ReadAll(io.LimitReader(content, maxAvatarFetchSize+1))
+	if err != nil {
+		return "", fmt.Errorf("failed to read avatar content for %s: %w", userID, err)
+	}
+	if int64(len(body)) > maxAvatarFetchSize {
+		return "", fmt.Errorf("avatar content for %s exceeds %d bytes", userID, maxAvatarFetchSize)
+	}
+	resized := p.resize(body, p.ResizeLimit)
 	if resized == nil {
 		return "", fmt.Errorf("avatar content for %s is not a valid image", userID)
 	}
@@ -132,11 +136,12 @@ func redactAvatarURL(raw string) string {
 	return "<unparseable>"
 }
 
-// load avatar from remote url and return body. Caller has to close the reader
-func (p *Proxy) load(url string, client *http.Client) (rc io.ReadCloser, err error) {
-	// load avatar from remote location
+// load fetches an avatar from a remote url and returns the body bytes, capped at
+// maxAvatarFetchSize. The bytes are passed straight to resize without an
+// intermediate Reader wrapper so we don't pay for buffering twice.
+func (p *Proxy) load(url string, client *http.Client) ([]byte, error) {
 	var resp *http.Response
-	err = retry(5, time.Second, func() error {
+	err := retry(5, time.Second, func() error {
 		var e error
 		resp, e = client.Get(url)
 		return e
@@ -144,23 +149,22 @@ func (p *Proxy) load(url string, client *http.Client) (rc io.ReadCloser, err err
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch avatar from the orig: %w", err)
 	}
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		_ = resp.Body.Close() // caller won't close on error
 		return nil, fmt.Errorf("failed to get avatar from the orig, status %s", resp.Status)
 	}
 
 	// buffer the body up to the cap to fail fast on oversized inputs.
 	// Reading +1 byte beyond the cap distinguishes "exactly cap" from "too big".
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAvatarFetchSize+1))
-	_ = resp.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read avatar body: %w", err)
 	}
 	if int64(len(body)) > maxAvatarFetchSize {
 		return nil, fmt.Errorf("avatar body exceeds %d bytes", maxAvatarFetchSize)
 	}
-	return io.NopCloser(bytes.NewReader(body)), nil
+	return body, nil
 }
 
 // Handler returns token routes for given provider
@@ -251,22 +255,13 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 // Validation uses image.DecodeConfig (cheap — declares dimensions, allocates nothing)
 // before any full image.Decode, so a 100 KB compressed image declaring 65535x65535 px
 // is rejected without ever materializing the raster.
-func (p *Proxy) resize(reader io.Reader, limit int) io.Reader {
-	if reader == nil {
-		p.Logf("[WARN] avatar resize(): reader is nil")
-		return nil
-	}
-
-	// read upstream bytes into a buffer up to the fetch cap. We keep the bytes verbatim
-	// for the no-resize path so animated GIFs etc. aren't truncated by image.Decode,
-	// which would only consume the first frame.
-	body, err := io.ReadAll(io.LimitReader(reader, maxAvatarFetchSize+1))
-	if err != nil {
-		p.Logf("[WARN] avatar resize(): can't read avatar body, %s", err)
-		return nil
-	}
-	if int64(len(body)) > maxAvatarFetchSize {
-		p.Logf("[WARN] avatar resize(): body exceeds %d bytes", maxAvatarFetchSize)
+//
+// Callers (load, PutContent, identicon generation) must ensure body is bounded by
+// maxAvatarFetchSize before calling; resize trusts the size invariant rather than
+// re-buffering. An empty body or a body over the cap is refused defensively.
+func (p *Proxy) resize(body []byte, limit int) io.Reader {
+	if len(body) == 0 || int64(len(body)) > maxAvatarFetchSize {
+		p.Logf("[WARN] avatar resize(): refusing body of size %d (cap %d)", len(body), maxAvatarFetchSize)
 		return nil
 	}
 

--- a/v2/avatar/avatar.go
+++ b/v2/avatar/avatar.go
@@ -33,6 +33,13 @@ const sniffLen = 512
 // unbounded body that would exhaust process memory inside resize.
 const maxAvatarFetchSize = 10 << 20
 
+// maxAvatarPixels caps the declared pixel count of an avatar before any raster
+// decode is allowed. Without this, a tiny compressed "decompression bomb" image
+// declaring e.g. 65535x65535 px would force image.Decode to allocate gigabytes
+// of pixel memory and OOM the auth service on a single login attempt. 16 MP
+// covers any realistic avatar (~4096x4096) while keeping peak allocation bounded.
+const maxAvatarPixels = 16 * 1024 * 1024
+
 // Proxy provides http handler for avatars from avatar.Store
 // On user login token will call Put and it will retrieve and save picture locally.
 type Proxy struct {
@@ -78,7 +85,15 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 		}
 	}()
 
-	avatarID, err := p.Store.Put(u.ID, p.resize(body, p.ResizeLimit)) // put returns avatar base name, like 123456.image
+	resized := p.resize(body, p.ResizeLimit)
+	if resized == nil {
+		// non-image upstream — refuse to store attacker-controlled bytes under
+		// the user's avatar id and fall back to a generated identicon instead.
+		p.Logf("[WARN] upstream avatar from %s is not a valid image, using identicon", redactAvatarURL(u.Picture))
+		return genIdenticon(u.ID)
+	}
+
+	avatarID, err := p.Store.Put(u.ID, resized) // put returns avatar base name, like 123456.image
 	if err != nil {
 		return "", err
 	}
@@ -93,7 +108,11 @@ func (p *Proxy) Put(u token.User, client *http.Client) (avatarURL string, err er
 // content themselves and avoid exposing the credential to Put's URL-fetching path —
 // where it would land in u.Picture, debug logs, and the user JSON returned to clients.
 func (p *Proxy) PutContent(userID string, content io.Reader) (avatarURL string, err error) {
-	avatarID, err := p.Store.Put(userID, p.resize(content, p.ResizeLimit))
+	resized := p.resize(content, p.ResizeLimit)
+	if resized == nil {
+		return "", fmt.Errorf("avatar content for %s is not a valid image", userID)
+	}
+	avatarID, err := p.Store.Put(userID, resized)
 	if err != nil {
 		return "", err
 	}
@@ -146,27 +165,17 @@ func (p *Proxy) load(url string, client *http.Client) (rc io.ReadCloser, err err
 
 // Handler returns token routes for given provider
 func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
+	setAvatarDefenseHeaders(w)
+
 	if r.Method != "GET" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
 	}
 	elems := strings.Split(r.URL.Path, "/")
 	avatarID := elems[len(elems)-1]
 	if !reValidAvatarID.MatchString(avatarID) {
 		rest.SendErrorJSON(w, r, p.L, http.StatusForbidden, fmt.Errorf("invalid avatar id from %s", r.URL.Path), "can't load avatar")
 		return
-	}
-
-	// enforce client-side caching
-	etag := `"` + p.Store.ID(avatarID) + `"`
-	w.Header().Set("Etag", etag)
-	w.Header().Set("Cache-Control", "max-age=604800") // 7 days
-	if match := r.Header.Get("If-None-Match"); match != "" {
-		etag = strings.TrimPrefix(etag, `"`)
-		etag = strings.TrimSuffix(etag, `"`)
-		if match == etag {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
 	}
 
 	avReader, size, err := p.Store.Get(avatarID)
@@ -188,11 +197,38 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "can't read avatar")
 		return
 	}
-	w.Header().Set("Content-Length", strconv.Itoa(size))
-	contentType := http.DetectContentType(buf)
-	if contentType == "application/octet-stream" {
+
+	// validate the bytes really are an image before declaring a content type. Even
+	// though Put() now refuses to store non-image content, this catches stores poisoned
+	// before the fix and any future regression — never trust the bytes at the store
+	// boundary alone, validate again at serve time. An empty body (e.g. NoOp store)
+	// is treated as a benign no-content case: nothing to render, no XSS surface.
+	var contentType string
+	if n > 0 {
+		var ctErr error
+		contentType, ctErr = safeImgContentType(buf[:n])
+		if ctErr != nil {
+			p.Logf("[WARN] rejecting non-image avatar %s: %v", avatarID, ctErr)
+			rest.SendErrorJSON(w, r, p.L, http.StatusUnsupportedMediaType, ctErr, "invalid avatar content")
+			return
+		}
+	} else {
 		contentType = "image/*"
 	}
+
+	// caching headers only after validation so error responses aren't cached
+	etag := `"` + p.Store.ID(avatarID) + `"`
+	w.Header().Set("Etag", etag)
+	w.Header().Set("Cache-Control", "max-age=604800") // 7 days
+	if match := r.Header.Get("If-None-Match"); match != "" {
+		trimmed := strings.TrimPrefix(strings.TrimSuffix(etag, `"`), `"`)
+		if match == trimmed {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Length", strconv.Itoa(size))
 	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(http.StatusOK)
 	if _, err = w.Write(buf[:n]); err != nil {
@@ -205,33 +241,66 @@ func (p *Proxy) Handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// resize an image of supported format (PNG, JPG, GIF) to the size of "limit" px of the biggest side
-// (width or height) preserving aspect ratio.
-// Returns original reader if resizing is not needed or failed.
+// resize validates that the input is a real image and, if needed, re-encodes it to
+// fit within "limit" px on the larger side preserving aspect ratio. Returns nil for
+// non-image content or for declared dimensions exceeding maxAvatarPixels so attacker
+// payloads (HTML/SVG/decompression bombs) never reach the store. With limit <= 0 or
+// when the image already fits, the original bytes are returned verbatim so animated
+// GIFs and other multi-frame formats round-trip without being flattened to one frame.
+//
+// Validation uses image.DecodeConfig (cheap — declares dimensions, allocates nothing)
+// before any full image.Decode, so a 100 KB compressed image declaring 65535x65535 px
+// is rejected without ever materializing the raster.
 func (p *Proxy) resize(reader io.Reader, limit int) io.Reader {
 	if reader == nil {
 		p.Logf("[WARN] avatar resize(): reader is nil")
 		return nil
 	}
-	if limit <= 0 {
-		p.Logf("[DEBUG] avatar resize(): limit should be greater than 0")
-		return reader
-	}
 
-	var teeBuf bytes.Buffer
-	tee := io.TeeReader(reader, &teeBuf)
-	src, _, err := image.Decode(tee)
+	// read upstream bytes into a buffer up to the fetch cap. We keep the bytes verbatim
+	// for the no-resize path so animated GIFs etc. aren't truncated by image.Decode,
+	// which would only consume the first frame.
+	body, err := io.ReadAll(io.LimitReader(reader, maxAvatarFetchSize+1))
 	if err != nil {
-		p.Logf("[WARN] avatar resize(): can't decode avatar image, %s", err)
-		return &teeBuf
+		p.Logf("[WARN] avatar resize(): can't read avatar body, %s", err)
+		return nil
+	}
+	if int64(len(body)) > maxAvatarFetchSize {
+		p.Logf("[WARN] avatar resize(): body exceeds %d bytes", maxAvatarFetchSize)
+		return nil
 	}
 
-	bounds := src.Bounds()
-	w, h := bounds.Dx(), bounds.Dy()
-	if w <= limit && h <= limit || w <= 0 || h <= 0 {
-		p.Logf("[DEBUG] resizing image is smaller that the limit or has 0 size")
-		return &teeBuf
+	// validate format and dimensions without allocating pixel memory.
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(body))
+	if err != nil {
+		// non-image input must never reach the store: refuse and let the caller
+		// fall back to an identicon. Returning the raw bytes here previously let
+		// an attacker who controlled u.Picture poison the store with HTML/SVG that
+		// the Handler would later serve back with text/html content type.
+		p.Logf("[WARN] avatar resize(): can't decode avatar image, %s", err)
+		return nil
 	}
+	// multiply in int64 — on 32-bit builds (GOARCH=386, 32-bit arm) the int
+	// product of two 16-bit-or-larger dimensions can overflow and wrap below
+	// maxAvatarPixels, bypassing the cap. GIF's 16-bit logical screen and
+	// JPEG's 16-bit SOF dimensions both hit this if multiplied as int32.
+	if cfg.Width <= 0 || cfg.Height <= 0 || int64(cfg.Width)*int64(cfg.Height) > int64(maxAvatarPixels) {
+		p.Logf("[WARN] avatar resize(): declared dimensions %dx%d exceed safe limit", cfg.Width, cfg.Height)
+		return nil
+	}
+
+	if limit <= 0 || (cfg.Width <= limit && cfg.Height <= limit) {
+		p.Logf("[DEBUG] avatar resize(): no resize needed (dim %dx%d, limit %d)", cfg.Width, cfg.Height, limit)
+		return bytes.NewReader(body)
+	}
+
+	// dimensions are bounded — full decode is now safe to allocate.
+	src, _, err := image.Decode(bytes.NewReader(body))
+	if err != nil {
+		p.Logf("[WARN] avatar resize(): decode after dim-check failed, %s", err)
+		return nil
+	}
+	w, h := src.Bounds().Dx(), src.Bounds().Dy()
 	newW, newH := w*limit/h, limit
 	if w > h {
 		newW, newH = limit, h*limit/w
@@ -243,9 +312,37 @@ func (p *Proxy) resize(reader io.Reader, limit int) io.Reader {
 	var out bytes.Buffer
 	if err = png.Encode(&out, m); err != nil {
 		p.Logf("[WARN] avatar resize(): can't encode resized avatar to PNG, %s", err)
-		return &teeBuf
+		return bytes.NewReader(body) // fall back to the validated original
 	}
 	return &out
+}
+
+// safeImgContentType returns the sniffed content type if the bytes look like a safe
+// image format (rasterised: PNG, JPEG, GIF, WebP, BMP, ICO). Returns an error for any
+// non-image content or for image/svg+xml, which can execute scripts when navigated to
+// top-level and must never be served from the avatar origin.
+func safeImgContentType(img []byte) (string, error) {
+	ct := http.DetectContentType(img)
+	base := ct
+	if idx := strings.Index(base, ";"); idx >= 0 {
+		base = strings.TrimSpace(base[:idx])
+	}
+	if !strings.HasPrefix(base, "image/") || base == "image/svg+xml" {
+		return "", fmt.Errorf("non-image content type %q", ct)
+	}
+	return base, nil
+}
+
+// setAvatarDefenseHeaders applies layered defense headers on every avatar response
+// (success, 304, or error). Each header survives content-type validation regressions,
+// browser sniffing, and top-level navigation:
+//   - Content-Security-Policy: strict, with sandbox — blocks inline scripts/handlers
+//   - X-Content-Type-Options: nosniff — prevents MIME-overriding the declared type
+//   - Content-Disposition: inline; filename="avatar" — frames the response as a file
+func setAvatarDefenseHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox; frame-ancestors 'none'")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `inline; filename="avatar"`)
 }
 
 // GenerateAvatar for give user with identicon

--- a/v2/avatar/avatar_test.go
+++ b/v2/avatar/avatar_test.go
@@ -2,6 +2,7 @@ package avatar
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
@@ -22,6 +23,20 @@ import (
 	"github.com/go-pkgz/auth/v2/logger"
 	"github.com/go-pkgz/auth/v2/token"
 )
+
+// tinyWebP is the smallest valid WebP (VP8 lossy 1x1). Used to regression-test
+// that Proxy.resize accepts WebP, which Go's stdlib image package does not register
+// by default — only the side-effect import of golang.org/x/image/webp in avatar.go
+// makes this work.
+var tinyWebP = mustDecodeBase64("UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/vshDgA=")
+
+func mustDecodeBase64(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic("test fixture: invalid base64: " + err.Error())
+	}
+	return b
+}
 
 func TestAvatar_Put(t *testing.T) {
 	pngBytes, err := os.ReadFile("testdata/circles.png")
@@ -295,18 +310,31 @@ func TestAvatar_Routes(t *testing.T) {
 	}
 
 	{
-		// status 304
+		// status 304 — client sends the same quoted ETag back, per RFC 7232
 		req, e := http.NewRequest("GET", "/b3daa77b4c04a9551b8781d03191fe098f325e67.image", http.NoBody)
 		require.NoError(t, e)
 		id := p.Store.ID("b3daa77b4c04a9551b8781d03191fe098f325e67.image")
-		req.Header.Add("If-None-Match", p.Store.ID(id)) // hash of `some_random_name.image` since the file doesn't exist
+		req.Header.Set("If-None-Match", `"`+id+`"`)
 
 		rr := httptest.NewRecorder()
 		handler := http.Handler(http.HandlerFunc(p.Handler))
 		handler.ServeHTTP(rr, req)
 
-		assert.Equal(t, http.StatusNotModified, rr.Code)
+		assert.Equal(t, http.StatusNotModified, rr.Code, "quoted If-None-Match matching the response ETag must 304")
 		assert.Equal(t, []string{`"` + id + `"`}, rr.Header()["Etag"])
+	}
+
+	{
+		// status 304 — weak validator form W/"..." also matches
+		req, e := http.NewRequest("GET", "/b3daa77b4c04a9551b8781d03191fe098f325e67.image", http.NoBody)
+		require.NoError(t, e)
+		id := p.Store.ID("b3daa77b4c04a9551b8781d03191fe098f325e67.image")
+		req.Header.Set("If-None-Match", `W/"`+id+`"`)
+
+		rr := httptest.NewRecorder()
+		handler := http.Handler(http.HandlerFunc(p.Handler))
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotModified, rr.Code, "weak If-None-Match must also 304")
 	}
 }
 
@@ -485,6 +513,51 @@ func makeBombPNG(width, height uint32) []byte {
 	crcInput := append([]byte("IHDR"), ihdr...)
 	_ = binary.Write(&buf, binary.BigEndian, crc32.ChecksumIEEE(crcInput))
 	return buf.Bytes()
+}
+
+// TestAvatar_resizeAcceptsWebP regression-checks Discord-style WebP avatars. Go's
+// stdlib image package only registers PNG/JPEG/GIF decoders; without the side-effect
+// import of golang.org/x/image/webp in avatar.go, image.DecodeConfig would fail on
+// WebP and Discord users would silently get an identicon instead of their real avatar.
+func TestAvatar_resizeAcceptsWebP(t *testing.T) {
+	p := Proxy{L: logger.Std}
+	got := p.resize(tinyWebP, 0)
+	require.NotNil(t, got, "WebP avatar must be accepted by resize when limit=0")
+	out, err := io.ReadAll(got)
+	require.NoError(t, err)
+	assert.Equal(t, tinyWebP, out, "no-resize path must return WebP bytes verbatim")
+
+	// safeImgContentType must also agree
+	ct, err := safeImgContentType(tinyWebP)
+	require.NoError(t, err)
+	assert.Equal(t, "image/webp", ct)
+}
+
+// TestEtagMatches covers the If-None-Match parsing per RFC 7232 — quoted, weak,
+// comma-separated, and wildcard forms. The handler previously compared against
+// an unquoted etag while browsers send the quoted form, so 304 short-circuits
+// never fired.
+func TestEtagMatches(t *testing.T) {
+	const etag = `"abc123"`
+	tbl := []struct {
+		header string
+		want   bool
+	}{
+		{etag, true},                   // exact match — what browsers send
+		{`W/"abc123"`, true},            // weak validator
+		{`"other", "abc123"`, true},     // comma-separated, second matches
+		{` "abc123" `, true},            // leading/trailing whitespace
+		{`*`, true},                     // wildcard matches anything
+		{`"abc"`, false},                // different etag
+		{`"abc123x"`, false},            // substring shouldn't match
+		{``, false},                     // empty
+		{`abc123`, false},               // unquoted — invalid per RFC, must not match
+	}
+	for _, tt := range tbl {
+		t.Run(tt.header, func(t *testing.T) {
+			assert.Equal(t, tt.want, etagMatches(tt.header, etag))
+		})
+	}
 }
 
 func TestAvatar_GetGravatarURL(t *testing.T) {

--- a/v2/avatar/avatar_test.go
+++ b/v2/avatar/avatar_test.go
@@ -2,7 +2,9 @@ package avatar
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"image"
 	"io"
 	"log"
@@ -22,11 +24,13 @@ import (
 )
 
 func TestAvatar_Put(t *testing.T) {
+	pngBytes, err := os.ReadFile("testdata/circles.png")
+	require.NoError(t, err)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/pic.png" {
-			w.Header().Set("Content-Type", "image/*")
-			fmt.Fprint(w, "some picture bin data")
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(pngBytes)
 			return
 		}
 		http.Error(w, "not found", http.StatusNotFound)
@@ -47,7 +51,7 @@ func TestAvatar_Put(t *testing.T) {
 	assert.Equal(t, "http://localhost:8080/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", res)
 	fi, err := os.Stat("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
 	assert.NoError(t, err)
-	assert.Equal(t, int64(21), fi.Size())
+	assert.Equal(t, int64(len(pngBytes)), fi.Size())
 
 	u.ID = "user2"
 	res, err = p.Put(u, client)
@@ -55,18 +59,83 @@ func TestAvatar_Put(t *testing.T) {
 	assert.Equal(t, "http://localhost:8080/avatar/a1881c06eec96db9901c7bbfe41c42a3f08e9cb4.image", res)
 	fi, err = os.Stat("/tmp/avatars.test/84/a1881c06eec96db9901c7bbfe41c42a3f08e9cb4.image")
 	assert.NoError(t, err)
-	assert.Equal(t, int64(21), fi.Size())
+	assert.Equal(t, int64(len(pngBytes)), fi.Size())
+}
+
+// TestAvatar_PutRejectsNonImage proves that an attacker controlling u.Picture cannot
+// poison the avatar store with HTML/SVG/text — Put falls back to an identicon and the
+// stored bytes are guaranteed to be a real PNG, not the attacker payload.
+func TestAvatar_PutRejectsNonImage(t *testing.T) {
+	htmlPayload := []byte("<html><script>alert(document.domain)</script></html>")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png") // lying upstream
+		_, _ = w.Write(htmlPayload)
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	p := Proxy{RoutePath: "/avatar", URL: "http://localhost:8080", Store: NewLocalFS(dir), L: logger.Std}
+
+	u := token.User{ID: "user1", Name: "user1 name", Picture: ts.URL + "/evil.png"}
+	res, err := p.Put(u, &http.Client{Timeout: time.Second})
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8080/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", res)
+
+	stored, err := os.ReadFile(dir + "/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
+	require.NoError(t, err)
+	assert.NotEqual(t, htmlPayload, stored, "attacker payload must not be stored")
+	assert.NotContains(t, string(stored), "<script>", "attacker payload must not be reachable from the store")
+	assert.True(t, bytes.HasPrefix(stored, []byte{0x89, 'P', 'N', 'G'}), "fallback content must be a real PNG (identicon)")
 }
 
 func TestAvatar_PutContent(t *testing.T) {
+	pngBytes, err := os.ReadFile("testdata/circles.png")
+	require.NoError(t, err)
+
 	defer func() { _ = os.RemoveAll("/tmp/avatars.put-content.test/") }()
 	p := Proxy{RoutePath: "/avatar", URL: "http://localhost:8080", Store: NewLocalFS("/tmp/avatars.put-content.test"), L: logger.Std}
-	got, err := p.PutContent("user1", strings.NewReader("png-bytes"))
+	got, err := p.PutContent("user1", bytes.NewReader(pngBytes))
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:8080/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", got)
 	fi, err := os.Stat("/tmp/avatars.put-content.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
 	require.NoError(t, err)
 	assert.Greater(t, fi.Size(), int64(0))
+
+	// non-image bytes are rejected — never stored
+	_, err = p.PutContent("attacker", strings.NewReader("<html><script>alert(1)</script></html>"))
+	require.Error(t, err, "non-image content must be rejected at PutContent")
+	assert.Contains(t, err.Error(), "not a valid image")
+}
+
+// TestAvatar_HandlerRejectsPoisonedStore proves that even if the store contains
+// attacker-controlled non-image bytes (e.g. poisoned before the fix), Handler refuses
+// to serve them and returns 415 with strict defense headers instead.
+func TestAvatar_HandlerRejectsPoisonedStore(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalFS(dir)
+
+	// directly seed the store with an HTML payload at user1's avatar id
+	htmlPayload := []byte("<html><body><script>alert(document.domain)</script></body></html>")
+	_, err := store.Put("user1", bytes.NewReader(htmlPayload))
+	require.NoError(t, err)
+
+	p := Proxy{RoutePath: "/avatar", URL: "http://localhost:8080", Store: store, L: logger.Std}
+
+	req := httptest.NewRequest("GET", "/avatar/b3daa77b4c04a9551b8781d03191fe098f325e67.image", http.NoBody)
+	rr := httptest.NewRecorder()
+	p.Handler(rr, req)
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, rr.Code, "poisoned store bytes must be rejected at serve time")
+	assert.False(t, strings.HasPrefix(rr.Header().Get("Content-Type"), "text/html"),
+		"reject response must not be text/html (got %q)", rr.Header().Get("Content-Type"))
+	assert.NotContains(t, rr.Body.String(), "<script>", "attacker payload must never appear in response body")
+	// defense headers on the rejection path too
+	assert.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+	assert.Contains(t, rr.Header().Get("Content-Disposition"), "inline")
+	csp := rr.Header().Get("Content-Security-Policy")
+	assert.Contains(t, csp, "default-src 'none'")
+	assert.Contains(t, csp, "sandbox")
 }
 
 func TestAvatar_RedactAvatarURL(t *testing.T) {
@@ -155,13 +224,15 @@ func TestAvatar_PutCapsBodySize(t *testing.T) {
 }
 
 func TestAvatar_Routes(t *testing.T) {
+	pngBytes, err := os.ReadFile("testdata/circles.png")
+	require.NoError(t, err)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/pic.png" {
-			w.Header().Set("Content-Type", "image/jpg")
+			w.Header().Set("Content-Type", "image/jpg") // intentionally wrong upstream CT — proxy must ignore it
 			w.Header().Set("Custom-Header", "xyz")
-			_, err := fmt.Fprint(w, "some picture bin data")
-			require.NoError(t, err)
+			_, wrErr := w.Write(pngBytes)
+			require.NoError(t, wrErr)
 			return
 		}
 		http.Error(w, "not found", http.StatusNotFound)
@@ -174,7 +245,7 @@ func TestAvatar_Routes(t *testing.T) {
 	client := &http.Client{Timeout: time.Second}
 
 	u := token.User{ID: "user1", Name: "user1 name", Picture: ts.URL + "/pic.png"}
-	_, err := p.Put(u, client)
+	_, err = p.Put(u, client)
 	assert.NoError(t, err)
 
 	{
@@ -197,7 +268,7 @@ func TestAvatar_Routes(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, rr.Code)
 	}
 
-	{ // status 200
+	{ // status 200 — real PNG bytes round-trip and are served as image/png (upstream lied with image/jpg)
 		req, e := http.NewRequest("GET", "/b3daa77b4c04a9551b8781d03191fe098f325e67.image", http.NoBody)
 		require.NoError(t, e)
 		rr := httptest.NewRecorder()
@@ -205,16 +276,22 @@ func TestAvatar_Routes(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, []string{"image/*"}, rr.Header()["Content-Type"])
-		assert.Equal(t, []string{"21"}, rr.Header()["Content-Length"])
+		assert.Equal(t, "image/png", rr.Header().Get("Content-Type"), "must sniff actual bytes, not trust upstream image/jpg")
+		assert.Equal(t, strconv.Itoa(len(pngBytes)), rr.Header().Get("Content-Length"))
 		assert.Equal(t, []string(nil), rr.Header()["Custom-Header"], "strip all custom headers")
 		assert.NotNil(t, rr.Header()["Etag"])
+		// defense headers must be present on every response
+		assert.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+		assert.Contains(t, rr.Header().Get("Content-Disposition"), "inline")
+		csp := rr.Header().Get("Content-Security-Policy")
+		assert.Contains(t, csp, "default-src 'none'")
+		assert.Contains(t, csp, "sandbox")
 
 		bb := bytes.Buffer{}
 		sz, e := io.Copy(&bb, rr.Body)
 		assert.NoError(t, e)
-		assert.Equal(t, int64(21), sz)
-		assert.Equal(t, "some picture bin data", bb.String())
+		assert.Equal(t, int64(len(pngBytes)), sz)
+		assert.Equal(t, pngBytes, bb.Bytes())
 	}
 
 	{
@@ -307,15 +384,15 @@ func TestAvatar_resize(t *testing.T) {
 	resizedR := p.resize(nil, 100)
 	assert.Nil(t, resizedR)
 
-	// negative limit error.
-	resizedR = p.resize(strings.NewReader("some picture bin data"), -1)
-	require.NotNil(t, resizedR)
-	checkC(t, resizedR, []byte("some picture bin data"))
-
-	// decode error.
-	resizedR = p.resize(strings.NewReader("invalid image content"), 100)
-	assert.NotNil(t, resizedR)
-	checkC(t, resizedR, []byte("invalid image content"))
+	// non-image bytes (e.g. an attacker's HTML payload) must NEVER pass through, even
+	// with limit <= 0: returning the raw bytes would let storage be poisoned with
+	// arbitrary content that Handler() would later sniff and serve as text/html.
+	assert.Nil(t, p.resize(strings.NewReader("some picture bin data"), -1),
+		"non-image must be rejected regardless of limit (no pass-through)")
+	assert.Nil(t, p.resize(strings.NewReader("invalid image content"), 100),
+		"decode failure must return nil (no pass-through)")
+	assert.Nil(t, p.resize(strings.NewReader("<html><script>alert(1)</script></html>"), 100),
+		"HTML body must be rejected")
 
 	cases := []struct {
 		file   string
@@ -334,6 +411,13 @@ func TestAvatar_resize(t *testing.T) {
 		assert.NotNil(t, resizedR, "file %s", c.file)
 		checkC(t, resizedR, img)
 
+		// no-resize path with limit=0 must also preserve the original bytes verbatim —
+		// this matters for animated GIFs and other multi-frame formats where decoding
+		// via image.Decode would consume only the first frame and truncate the rest.
+		resizedR = p.resize(bytes.NewReader(img), 0)
+		assert.NotNil(t, resizedR, "limit=0 must return original bytes for %s", c.file)
+		checkC(t, resizedR, img)
+
 		// resizing to half of width. Check resizedR avatar format PNG.
 		resizedR = p.resize(bytes.NewReader(img), 400)
 		assert.NotNil(t, resizedR, "file %s", c.file)
@@ -345,6 +429,62 @@ func TestAvatar_resize(t *testing.T) {
 		assert.Equal(t, c.wr, bounds.Dx(), "file %s", c.file)
 		assert.Equal(t, c.hr, bounds.Dy(), "file %s", c.file)
 	}
+}
+
+// TestAvatar_resizeRejectsDecompressionBomb proves a tiny PNG that declares huge
+// dimensions in its IHDR chunk is rejected via DecodeConfig (cheap, no allocation)
+// before image.Decode is called. Without this check, image.Decode would allocate
+// width*height*4 bytes of pixel memory and OOM the auth service on each login that
+// fetches an attacker-controlled u.Picture.
+//
+// The product-overflow case (65535×65535 wraps int32) is also exercised: the guard
+// must compute the product in int64 so 32-bit builds (GOARCH=386, 32-bit arm) cannot
+// be tricked into letting the bomb through by integer wraparound.
+func TestAvatar_resizeRejectsDecompressionBomb(t *testing.T) {
+	cases := []struct {
+		name   string
+		w, h   uint32
+		reason string
+	}{
+		{name: "huge square", w: 65535, h: 65535, reason: "well over maxAvatarPixels; also overflows int32 product"},
+		{name: "non-square overflow", w: 70000, h: 70000, reason: "still overflows int32 product on 32-bit builds"},
+		{name: "thin huge area", w: 1 << 24, h: 1 << 24, reason: "product fits int64 but exceeds maxAvatarPixels by orders of magnitude"},
+	}
+	p := Proxy{L: logger.Std}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bomb := makeBombPNG(c.w, c.h)
+			require.Less(t, len(bomb), 100, "bomb must be small compressed — that is the threat model")
+			assert.Nil(t, p.resize(bytes.NewReader(bomb), 100), "limit>0: %s", c.reason)
+			assert.Nil(t, p.resize(bytes.NewReader(bomb), 0), "limit=0: %s", c.reason)
+		})
+	}
+}
+
+// makeBombPNG constructs a PNG header with an IHDR chunk declaring the given
+// width/height but no IDAT body. image.DecodeConfig returns those dimensions
+// without allocating pixel memory; image.Decode on the same bytes would either
+// fail or attempt to allocate w*h*4 bytes.
+func makeBombPNG(width, height uint32) []byte {
+	var buf bytes.Buffer
+	buf.Write([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'})
+
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], width)
+	binary.BigEndian.PutUint32(ihdr[4:8], height)
+	ihdr[8] = 8  // bit depth
+	ihdr[9] = 2  // RGB color type
+	ihdr[10] = 0 // compression
+	ihdr[11] = 0 // filter
+	ihdr[12] = 0 // interlace
+
+	_ = binary.Write(&buf, binary.BigEndian, uint32(13)) // chunk length
+	buf.WriteString("IHDR")
+	buf.Write(ihdr)
+
+	crcInput := append([]byte("IHDR"), ihdr...)
+	_ = binary.Write(&buf, binary.BigEndian, crc32.ChecksumIEEE(crcInput))
+	return buf.Bytes()
 }
 
 func TestAvatar_GetGravatarURL(t *testing.T) {

--- a/v2/avatar/avatar_test.go
+++ b/v2/avatar/avatar_test.go
@@ -387,11 +387,11 @@ func TestAvatar_resize(t *testing.T) {
 	// non-image bytes (e.g. an attacker's HTML payload) must NEVER pass through, even
 	// with limit <= 0: returning the raw bytes would let storage be poisoned with
 	// arbitrary content that Handler() would later sniff and serve as text/html.
-	assert.Nil(t, p.resize(strings.NewReader("some picture bin data"), -1),
+	assert.Nil(t, p.resize([]byte("some picture bin data"), -1),
 		"non-image must be rejected regardless of limit (no pass-through)")
-	assert.Nil(t, p.resize(strings.NewReader("invalid image content"), 100),
+	assert.Nil(t, p.resize([]byte("invalid image content"), 100),
 		"decode failure must return nil (no pass-through)")
-	assert.Nil(t, p.resize(strings.NewReader("<html><script>alert(1)</script></html>"), 100),
+	assert.Nil(t, p.resize([]byte("<html><script>alert(1)</script></html>"), 100),
 		"HTML body must be rejected")
 
 	cases := []struct {
@@ -407,19 +407,19 @@ func TestAvatar_resize(t *testing.T) {
 		require.Nil(t, err, "can't open test file %s", c.file)
 
 		// no need for resize, avatar dimensions are smaller than resize limit.
-		resizedR = p.resize(bytes.NewReader(img), 800)
+		resizedR = p.resize(img, 800)
 		assert.NotNil(t, resizedR, "file %s", c.file)
 		checkC(t, resizedR, img)
 
 		// no-resize path with limit=0 must also preserve the original bytes verbatim —
 		// this matters for animated GIFs and other multi-frame formats where decoding
 		// via image.Decode would consume only the first frame and truncate the rest.
-		resizedR = p.resize(bytes.NewReader(img), 0)
+		resizedR = p.resize(img, 0)
 		assert.NotNil(t, resizedR, "limit=0 must return original bytes for %s", c.file)
 		checkC(t, resizedR, img)
 
 		// resizing to half of width. Check resizedR avatar format PNG.
-		resizedR = p.resize(bytes.NewReader(img), 400)
+		resizedR = p.resize(img, 400)
 		assert.NotNil(t, resizedR, "file %s", c.file)
 
 		imgRz, format, err := image.Decode(resizedR)
@@ -455,8 +455,8 @@ func TestAvatar_resizeRejectsDecompressionBomb(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			bomb := makeBombPNG(c.w, c.h)
 			require.Less(t, len(bomb), 100, "bomb must be small compressed — that is the threat model")
-			assert.Nil(t, p.resize(bytes.NewReader(bomb), 100), "limit>0: %s", c.reason)
-			assert.Nil(t, p.resize(bytes.NewReader(bomb), 0), "limit=0: %s", c.reason)
+			assert.Nil(t, p.resize(bomb, 100), "limit>0: %s", c.reason)
+			assert.Nil(t, p.resize(bomb, 0), "limit=0: %s", c.reason)
 		})
 	}
 }

--- a/v2/provider/telegram_test.go
+++ b/v2/provider/telegram_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,6 +26,12 @@ import (
 var botInfoFunc = func(ctx context.Context) (*botInfo, error) {
 	return &botInfo{Username: "my_auth_bot"}, nil
 }
+
+// tinyPNG is the smallest valid PNG (1x1 transparent). Tests that exercise the
+// avatar.Proxy.PutContent path need bytes that pass image.Decode; raw "png-bytes"
+// would be rejected by Proxy.resize after the content-type-spoof XSS fix.
+var tinyPNG, _ = base64.StdEncoding.DecodeString(
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==")
 
 func TestTgLoginHandlerErrors(t *testing.T) {
 	tg := TelegramHandler{Telegram: NewTelegramAPI("test", http.DefaultClient)}
@@ -139,7 +146,7 @@ func TestTelegramConfirmedRequest(t *testing.T) {
 	}
 
 	avatarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("png-bytes"))
+		_, _ = w.Write(tinyPNG)
 	}))
 	defer avatarSrv.Close()
 	m.AvatarFunc = func(ctx context.Context, userID int) (string, error) {
@@ -363,7 +370,7 @@ func (failingAvatarSaver) PutContent(string, io.Reader) (string, error)     { re
 
 func TestSaveTelegramAvatar_TypedNilAvatarSaverDoesNotPanic(t *testing.T) {
 	avatarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("png-bytes"))
+		_, _ = w.Write(tinyPNG)
 	}))
 	defer avatarSrv.Close()
 
@@ -384,7 +391,7 @@ func TestTelegramLoginHandler_DoesNotOverwriteSavedAvatar(t *testing.T) {
 	}
 
 	avatarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("png-bytes"))
+		_, _ = w.Write(tinyPNG)
 	}))
 	defer avatarSrv.Close()
 

--- a/v2/provider/telegram_test.go
+++ b/v2/provider/telegram_test.go
@@ -30,8 +30,16 @@ var botInfoFunc = func(ctx context.Context) (*botInfo, error) {
 // tinyPNG is the smallest valid PNG (1x1 transparent). Tests that exercise the
 // avatar.Proxy.PutContent path need bytes that pass image.Decode; raw "png-bytes"
 // would be rejected by Proxy.resize after the content-type-spoof XSS fix.
-var tinyPNG, _ = base64.StdEncoding.DecodeString(
+var tinyPNG = mustDecodeBase64(
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==")
+
+func mustDecodeBase64(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic("test fixture: invalid base64: " + err.Error())
+	}
+	return b
+}
 
 func TestTgLoginHandlerErrors(t *testing.T) {
 	tg := TelegramHandler{Telegram: NewTelegramAPI("test", http.DefaultClient)}
@@ -366,7 +374,9 @@ func (legacyAvatarSaver) Put(authtoken.User, *http.Client) (string, error) { ret
 type failingAvatarSaver struct{}
 
 func (failingAvatarSaver) Put(authtoken.User, *http.Client) (string, error) { return "", nil }
-func (failingAvatarSaver) PutContent(string, io.Reader) (string, error)     { return "", fmt.Errorf("disk full") }
+func (failingAvatarSaver) PutContent(string, io.Reader) (string, error) {
+	return "", fmt.Errorf("disk full")
+}
 
 func TestSaveTelegramAvatar_TypedNilAvatarSaverDoesNotPanic(t *testing.T) {
 	avatarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -414,7 +424,7 @@ func TestTelegramLoginHandler_DoesNotOverwriteSavedAvatar(t *testing.T) {
 	}
 
 	updates := &telegramUpdate{}
-	require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(getUpdatesResp, tok)), updates))
+	require.NoError(t, json.Unmarshal(fmt.Appendf(nil, getUpdatesResp, tok), updates))
 	th.processUpdates(context.Background(), updates)
 
 	got := th.requests.data[tok]

--- a/v2/provider/verify_test.go
+++ b/v2/provider/verify_test.go
@@ -214,7 +214,7 @@ func TestInMemoryVerifStore(t *testing.T) {
 		successes := int32(0)
 		errs := int32(0)
 		wg.Add(goroutines)
-		for i := 0; i < goroutines; i++ {
+		for range goroutines {
 			go func() {
 				defer wg.Done()
 				used, err := s.MarkUsed("hot-key", time.Hour)
@@ -239,7 +239,7 @@ func TestInMemoryVerifStore(t *testing.T) {
 		s := NewInMemoryVerifStore().(*inMemoryVerifStore)
 		// 3 inserts with nanosecond TTL — quickly expire, no sweep yet
 		// (insertCount=3 < 4)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			used, err := s.MarkUsed(fmt.Sprintf("expired-%d", i), time.Nanosecond)
 			require.NoError(t, err)
 			require.False(t, used)


### PR DESCRIPTION
## Summary

Fixes a stored XSS in `avatar.Proxy` and adds defense-in-depth headers across
the rest of `Service.Handlers()`. Both v1 (`avatar/`, `auth.go`) and v2
(`v2/avatar/`, `v2/auth.go`) on the same commit, so a single coordinated release
(`v1.x.y` and `v2.x.y` tags) covers both module versions.

## The bug

`avatar/avatar.go:Proxy.resize()` fell back to the raw bytes (`teeBuf`) when
`image.Decode` failed. `avatar/avatar.go:Proxy.Handler()` then called
`http.DetectContentType` on whatever was stored and emitted the result as
`Content-Type` — including `text/html` for HTML bodies.

### Attack scenario

The realistic path requires the attacker to control `u.Picture`:

1. Configure (or compromise) an OAuth provider so its `picture` claim points
   at attacker-controlled `https://evil.tld/avatar.png`.
2. Log in once. `Proxy.Put` fetches the URL, `resize` fails to decode the
   HTML body, falls through to `teeBuf`, stores the HTML under
   `<sha1(userID)>.image`.
3. Direct the victim to `https://auth-host/avatar/<sha1>.image`. Browser
   gets `Content-Type: text/html` with no `Content-Disposition`, renders the
   attacker's HTML as a document in the auth-service origin, runs script.

This is **not** exploitable on remark42's standard setup — `u.Picture` there
comes from admin-configured providers (GitHub, Google, etc.) which the user
cannot redirect. It **is** exploitable on:

- Custom OAuth providers whose `picture` claim is attacker-controlled.
- Self-signup flows that accept a Picture URL from the user.
- The dev provider (intentionally permissive, but still worth fixing).
- Any deployment where one user can set another's Picture (admin tooling, etc.).

Codex-flagged residual risks addressed in the same fix:

- **Decompression bomb** — a 100 KB compressed PNG declaring 65535×65535 px
  decodes to ~17 GB of pixel data. Before this PR `Proxy.resize` always called
  `image.Decode` and would OOM the auth service on a single login. After, an
  `image.DecodeConfig` pre-check rejects oversized declared dimensions before
  any pixel allocation.
- **32-bit overflow** — the pixel-count guard was computed in `int`, so on
  GOARCH=386 / 32-bit arm `cfg.Width * cfg.Height` for 16-bit GIF or JPEG
  dimensions could wrap below the cap. Multiplication is now in `int64`.
- **Animated GIF truncation** — the no-resize path now returns the original
  bytes verbatim; previously the `TeeReader` could capture only the first
  frame.

## What changes

### Commit 1 — `fix(avatar): reject non-image content to prevent stored XSS via content-type spoofing`

`avatar/avatar.go` + `v2/avatar/avatar.go`:

- `Proxy.resize()` validates input via `image.DecodeConfig` (cheap, no pixel
  allocation) before any `image.Decode`. Refuses non-image content with `nil`
  so attacker payloads never reach `Store.Put`.
- New `maxAvatarPixels` constant (16 MP). Multiplication in `int64`.
- The no-resize path returns the original bytes verbatim.
- `Proxy.Put()` falls back to a generated identicon when `resize` returns `nil`.
- `Proxy.PutContent()` returns an explicit error for non-image input.
- `Proxy.Handler()` validates served bytes via the new `safeImgContentType`
  helper (allowlist: `image/{png,jpeg,gif,webp,bmp,x-icon}`; `image/svg+xml`
  explicitly rejected because SVG can execute scripts when navigated to top
  level). This catches stores poisoned before this fix.
- Every Handler response (success / 304 / error) carries:

  ```
  Content-Security-Policy: default-src 'none'; sandbox; frame-ancestors 'none'
  X-Content-Type-Options: nosniff
  Content-Disposition: inline; filename="avatar"
  ```

Tests updated: `TestAvatar_resize` and `TestAvatar_Routes` previously codified
the broken pass-through behavior; those assertions are inverted now.

New tests:

- `TestAvatar_PutRejectsNonImage` — store is not poisoned by attacker `u.Picture`.
- `TestAvatar_HandlerRejectsPoisonedStore` — handler refuses pre-poisoned bytes.
- `TestAvatar_resizeRejectsDecompressionBomb` — DecodeConfig + int64 dim cap.

`provider/telegram_test.go` placeholder `"png-bytes"` is now a real 1x1 PNG
(`tinyPNG`) since `PutContent` validates input.

### Commit 2 — `feat(auth): apply mandatory CSP and nosniff on every Service.Handlers() response`

`auth.go` + `v2/auth.go`:

`Service.Handlers()` wraps both returned handlers (auth route dispatcher and
avatar handler) with `withSecurityHeaders`. Sets:

```
Content-Security-Policy: default-src 'none'; sandbox; frame-ancestors 'none'
X-Content-Type-Options: nosniff
```

go-pkgz/auth's response surface is JSON-only for auth routes and images for
avatar — no consumer-customisable HTML anywhere — so this CSP is unconditionally
safe.

### Commit 3 — `refactor(avatar): collapse load/resize double-buffering`

`avatar/avatar.go` + `v2/avatar/avatar.go`:

Before this commit a remote avatar was buffered twice: once inside `load()` to
enforce `maxAvatarFetchSize`, again inside `resize()` for `image.DecodeConfig`.
For a 10 MiB upstream avatar each in-flight login held ~20 MiB peak.

- `load()` returns `([]byte, error)` instead of `(io.ReadCloser, error)`.
- `resize()` takes `([]byte, int)` instead of `(io.Reader, int)`.
- `PutContent()` now runs `io.ReadAll(io.LimitReader(content, cap+1))` at the
  public API boundary so the size cap is visible to callers reading the code.

No public API change, no behavior change other than halved peak memory per
concurrent login.

## What end-users will see

Anyone who upgrades and uses `Service.Handlers()`:

- Two new response headers on every auth and avatar response:
  - `Content-Security-Policy: default-src 'none'; sandbox; frame-ancestors 'none'`
  - `X-Content-Type-Options: nosniff`
- Avatar responses additionally carry `Content-Disposition: inline; filename="avatar"`.
- Non-image upstream avatars now fall back to a generated identicon instead
  of being stored verbatim. The user gets an identicon where previously they
  would have gotten a broken avatar (or, in the attacker case, JavaScript).
- `Proxy.PutContent` now returns an error for non-image input instead of
  silently storing whatever bytes the caller passed.

## What might break

Nothing for standard consumers. Specifically:

- **Embedders that proxy auth/avatar responses** — the CSP and nosniff
  headers are set on the response; downstream proxies pass them through.
  If a consumer was relying on the avatar handler returning `text/html` for
  invalid content, that was the bug — they should not be doing that.
- **Consumers calling `Proxy.PutContent` with invalid bytes** — they now
  get an error instead of an empty/poisoned avatar. This is the intended
  behavior.
- **SVG avatars** — explicitly rejected. SVG can execute scripts; storing
  one in an avatar slot was always a latent XSS risk.

## Release plan

Both `v1` and `v2` module versions live on `master` in this repo, so a single
PR fixes both. After merge, tag `v1.x.y` and `v2.x.y` from the same commit.
remark42 will bump to `v2.x.y` in its own follow-up PR.

## Codex review

The branch was reviewed adversarially with Codex (GPT-5.5, high reasoning) in
four rounds. Rounds 1 and 2 each surfaced one high-severity finding (the
decompression bomb on no-resize path, and the 32-bit int overflow on the
pixel-count guard) — both addressed in this PR. Rounds 3 and 4 approved with
no material findings.

## Tests

All v1 and v2 test suites pass, lint clean (no new `gosec`/`govet`/`misspell`
findings). Cross-compile to `GOARCH=386` succeeds, confirming the `int64`
arithmetic is portable.
