### PR TITLE
fix(example): incorrect callback urls after stripping route prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ func main() {
 
 	// setup auth routes
 	authRoutes, avaRoutes := service.Handlers()
-	router.Handle("/auth/", http.StripPrefix("/auth", authRoutes))   // add auth handlers
-	router.Handle("/avatar/", http.StripPrefix("/avatar", avaRoutes)) // add avatar handler
+	router.Handle("/auth/", authRoutes) // add auth handlers
+	router.Handle("/avatar/", avaRoutes) // add avatar handler
 
 	log.Fatal(http.ListenAndServe(":8080", router))
 }

--- a/_example/main.go
+++ b/_example/main.go
@@ -206,8 +206,8 @@ func main() {
 
 	// setup auth routes
 	authRoutes, avaRoutes := service.Handlers()
-	router.Handle("/auth/", http.StripPrefix("/auth", authRoutes))    // add auth handlers
-	router.Handle("/avatar/", http.StripPrefix("/avatar", avaRoutes)) // add avatar handler
+	router.Handle("/auth/", authRoutes)  // add auth handlers
+	router.Handle("/avatar/", avaRoutes) // add avatar handler
 
 	httpServer := &http.Server{
 		Addr:              ":8080",


### PR DESCRIPTION
Fixes the wrong redirect url in the example.

Step to reproduce:
1. set up google provider in `_example/main.go`, run the app
2. open http://localhost:8080/web, click google
3. google oauth handler errors with `Error 400: redirect_uri_mismatch`

This happens due to `r.URL.Path` being `/google/login` instead of `/auth/google/login` in `LoginHander` https://github.com/go-pkgz/auth/blob/master/v2/provider/oauth2.go#L143 .

