### PR TITLE
feat(avatar): add ErrNotFound sentinel returned by Store.Remove

### DIFF
--- a/v2/avatar/bolt.go
+++ b/v2/avatar/bolt.go
@@ -103,7 +103,7 @@ func (b *BoltDB) Remove(avatarID string) (err error) {
 	return b.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket([]byte(avatarsBktName))
 		if bkt.Get([]byte(avatarID)) == nil {
-			return fmt.Errorf("avatar key not found, %s", avatarID)
+			return fmt.Errorf("avatar %s not found: %w", avatarID, ErrNotFound)
 		}
 		if err = tx.Bucket([]byte(avatarsBktName)).Delete([]byte(avatarID)); err != nil {
 			return fmt.Errorf("can't delete avatar object %s: %w", avatarID, err)

--- a/v2/avatar/bolt_test.go
+++ b/v2/avatar/bolt_test.go
@@ -47,13 +47,13 @@ func TestBoltDB_Remove(t *testing.T) {
 	b, teardown := prepBoltStore(t)
 	defer teardown()
 
-	assert.Error(t, b.Remove("no-such-thing.image"))
+	assert.ErrorIs(t, b.Remove("no-such-thing.image"), ErrNotFound)
 
 	avatar, err := b.Put("user1", strings.NewReader("some picture bin data"))
 	require.Nil(t, err)
 	assert.Equal(t, "b3daa77b4c04a9551b8781d03191fe098f325e67.image", avatar)
 	assert.NoError(t, b.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "remove real one")
-	assert.Error(t, b.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "already removed")
+	assert.ErrorIs(t, b.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), ErrNotFound, "already removed")
 }
 
 func TestBoltDB_List(t *testing.T) {

--- a/v2/avatar/gridfs.go
+++ b/v2/avatar/gridfs.go
@@ -116,7 +116,7 @@ func (gf *GridFS) Remove(avatar string) error {
 		}
 		return bucket.Delete(r.ID)
 	}
-	return fmt.Errorf("avatar %s not found", avatar)
+	return fmt.Errorf("avatar %s not found: %w", avatar, ErrNotFound)
 }
 
 // List all avatars (ids) on gfs

--- a/v2/avatar/gridfs_test.go
+++ b/v2/avatar/gridfs_test.go
@@ -49,12 +49,12 @@ func TestGridFS_Remove(t *testing.T) {
 	}
 	p := prepGFStore(t)
 	defer p.Close()
-	assert.Error(t, p.Remove("no-such-thing.image"))
+	assert.ErrorIs(t, p.Remove("no-such-thing.image"), ErrNotFound)
 	avatar, err := p.Put("user1", strings.NewReader("some picture bin data"))
 	require.Nil(t, err)
 	assert.Equal(t, "b3daa77b4c04a9551b8781d03191fe098f325e67.image", avatar)
 	assert.NoError(t, p.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "remove real one")
-	assert.Error(t, p.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), "already removed")
+	assert.ErrorIs(t, p.Remove("b3daa77b4c04a9551b8781d03191fe098f325e67.image"), ErrNotFound, "already removed")
 }
 
 func TestGridFS_List(t *testing.T) {

--- a/v2/avatar/localfs.go
+++ b/v2/avatar/localfs.go
@@ -1,6 +1,7 @@
 package avatar
 
 import (
+	"errors"
 	"fmt"
 	"hash/crc64"
 	"io"
@@ -82,7 +83,13 @@ func (fs *LocalFS) ID(avatar string) (id string) {
 func (fs *LocalFS) Remove(avatar string) error {
 	location := fs.location(strings.TrimSuffix(avatar, imgSfx))
 	avFile := path.Join(location, avatar)
-	return os.Remove(avFile)
+	if err := os.Remove(avFile); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("avatar %s not found: %w", avatar, ErrNotFound)
+		}
+		return err
+	}
+	return nil
 }
 
 // List all avatars (ids) on local file system

--- a/v2/avatar/localfs.go
+++ b/v2/avatar/localfs.go
@@ -85,7 +85,9 @@ func (fs *LocalFS) Remove(avatar string) error {
 	avFile := path.Join(location, avatar)
 	if err := os.Remove(avFile); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("avatar %s not found: %w", avatar, ErrNotFound)
+			// keep the underlying os.ErrNotExist in the chain alongside ErrNotFound so callers that
+			// already matched errors.Is(err, os.ErrNotExist) on this store keep working
+			return fmt.Errorf("avatar %s not found: %w: %w", avatar, ErrNotFound, err)
 		}
 		return err
 	}

--- a/v2/avatar/localfs_test.go
+++ b/v2/avatar/localfs_test.go
@@ -125,7 +125,7 @@ func TestAvatarStoreFS_Remove(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll("/tmp/avatars.test")
 
-	assert.Error(t, p.Remove("no-such-avatar"), "remove non-existing avatar")
+	assert.ErrorIs(t, p.Remove("no-such-avatar"), ErrNotFound, "remove non-existing avatar")
 	err = os.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
 	require.NoError(t, err)
 
@@ -133,6 +133,23 @@ func TestAvatarStoreFS_Remove(t *testing.T) {
 	_, err = os.Stat("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image")
 	assert.Error(t, err, "removed for real")
 	t.Log(err)
+}
+
+func TestAvatarStoreFS_RemoveError(t *testing.T) {
+	const store = "/tmp/avatars.test.err"
+	p := NewLocalFS(store)
+	defer os.RemoveAll(store)
+
+	// put a non-empty directory where Remove expects a file, so os.Remove fails with a real error
+	// (not "not exist"); that error must be returned as-is, not masked as ErrNotFound
+	const avatarID = "b3daa77b4c04a9551b8781d03191fe098f325e67.image" // hashes to partition 30
+	avFile := store + "/30/" + avatarID
+	require.NoError(t, os.MkdirAll(avFile, 0o700))
+	require.NoError(t, os.WriteFile(avFile+"/child", []byte("x"), 0o600))
+
+	err := p.Remove(avatarID)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound, "a genuine removal error must not be reported as ErrNotFound")
 }
 
 func TestAvatarStoreFS_List(t *testing.T) {

--- a/v2/avatar/localfs_test.go
+++ b/v2/avatar/localfs_test.go
@@ -125,7 +125,9 @@ func TestAvatarStoreFS_Remove(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll("/tmp/avatars.test")
 
-	assert.ErrorIs(t, p.Remove("no-such-avatar"), ErrNotFound, "remove non-existing avatar")
+	rmErr := p.Remove("no-such-avatar")
+	assert.ErrorIs(t, rmErr, ErrNotFound, "remove non-existing avatar")
+	assert.ErrorIs(t, rmErr, os.ErrNotExist, "localfs keeps the underlying os.ErrNotExist in the chain")
 	err = os.WriteFile("/tmp/avatars.test/30/b3daa77b4c04a9551b8781d03191fe098f325e67.image", []byte("something"), 0666) //nolint
 	require.NoError(t, err)
 

--- a/v2/avatar/store.go
+++ b/v2/avatar/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha1" //nolint gosec
 	"encoding/hex"
+	"errors"
 	"fmt"
 	_ "image/gif"  // initializing packages for supporting GIF
 	_ "image/jpeg" // initializing packages for supporting JPEG.
@@ -26,6 +27,10 @@ import (
 const imgSfx = ".image"
 
 var reValidAvatarID = regexp.MustCompile(`^[a-fA-F0-9]{40}\.image$`)
+
+// ErrNotFound is returned by Store.Remove when the requested avatar does not exist,
+// so callers can tell a missing avatar from a real failure with errors.Is.
+var ErrNotFound = errors.New("avatar not found")
 
 // Store defines interface to store and load avatars
 type Store interface {


### PR DESCRIPTION
## What

The three avatar stores each reported a missing avatar differently from `Remove`:

- `LocalFS` — `os.Remove` → `os.ErrNotExist`
- `BoltDB` — `fmt.Errorf("avatar key not found, %s", ...)` (bare string)
- `GridFS` — `fmt.Errorf("avatar %s not found", ...)` (bare string)

So a caller had no reliable, portable way to tell "avatar already gone" from a genuine failure — it would have to string-match, and even that differs per store.

## Change

- Add an exported `ErrNotFound` sentinel.
- Return it (wrapped with `%w`) from all three `Remove` implementations when the avatar does not exist, so callers can use `errors.Is(err, avatar.ErrNotFound)`.
- Strengthen the existing `Remove` not-found tests from `assert.Error` to `assert.ErrorIs(..., ErrNotFound)`.

## Why

Downstream (e.g. remark42's account-deletion flow) needs to treat an already-removed avatar as success while still surfacing real errors. Today that's impossible to do portably across the stores; this makes it a one-liner.