### PR TITLE
ci: go 1.26, golangci-lint v2.12, address new gosec findings

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -2,8 +2,8 @@ name: build-v2
 
 on:
   push:
-    branches:
-    tags:
+    branches: ["**"]
+    tags: ["**"]
     paths:
       - ".github/workflows/ci-v2.yml"
       - "v2/**"
@@ -59,7 +59,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
-          args: --config ../.golangci.yml
+          args: --config=../.golangci.yml
           working-directory: v2
 
       - name: submit coverage

--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -30,7 +30,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: v2/go.sum
         id: go
 
@@ -56,9 +56,9 @@ jobs:
           ENABLE_MONGO_TESTS: "true"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6.2
+          version: v2.12.2
           args: --config ../.golangci.yml
           working-directory: v2
 

--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -25,7 +25,7 @@ jobs:
           sudo systemctl disable mono-xsp4.service || true
 
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: set up go
         uses: actions/setup-go@v6
@@ -48,7 +48,7 @@ jobs:
 
       - name: build and test
         run: |
-          go test -timeout=60s -v -race -p 1 -covermode=atomic -coverprofile=$GITHUB_WORKSPACE/profile.cov ./...
+          go test -timeout=60s -v -race -p 1 -covermode=atomic -coverprofile="$GITHUB_WORKSPACE/profile.cov" ./...
           go build -race
         working-directory: v2
         env:
@@ -65,6 +65,6 @@ jobs:
       - name: submit coverage
         run: |
           go install github.com/mattn/goveralls@latest
-          goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
+          goveralls -service="github" -coverprofile="$GITHUB_WORKSPACE/profile.cov"
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
         id: go
 
       - name: launch mongodb
@@ -47,9 +47,9 @@ jobs:
           ENABLE_MONGO_TESTS: "true"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6.2
+          version: v2.12.2
 
       - name: submit coverage
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           sudo systemctl disable mono-xsp4.service || true
 
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: set up go
         uses: actions/setup-go@v6
@@ -40,7 +40,7 @@ jobs:
 
       - name: build and test
         run: |
-          go test -timeout=60s -v -race -p 1 -covermode=atomic -coverprofile=$GITHUB_WORKSPACE/profile.cov ./...
+          go test -timeout=60s -v -race -p 1 -covermode=atomic -coverprofile="$GITHUB_WORKSPACE/profile.cov" ./...
           go build -race
         env:
           TZ: "America/Chicago"
@@ -54,6 +54,6 @@ jobs:
       - name: submit coverage
         run: |
           go install github.com/mattn/goveralls@latest
-          goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
+          goveralls -service="github" -coverprofile="$GITHUB_WORKSPACE/profile.cov"
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: build
 
 on:
   push:
-    branches:
-    tags:
+    branches: ["**"]
+    tags: ["**"]
     paths-ignore:
       - ".github/workflows/ci-v2.yml"
       - "v2/**"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,4 +53,4 @@ jobs:
         TZ: "America/Chicago"
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,9 @@ linters:
       - linters:
           - errcheck
         path: _test\.go$
+      - linters:
+          - gosec
+        path: _test\.go$
       - path: (.+)\.go$
         text: should have a package comment, unless it's in another file for this package
       - path: (.+)\.go$

--- a/avatar/avatar_test.go
+++ b/avatar/avatar_test.go
@@ -543,15 +543,15 @@ func TestEtagMatches(t *testing.T) {
 		header string
 		want   bool
 	}{
-		{etag, true},                   // exact match — what browsers send
-		{`W/"abc123"`, true},            // weak validator
-		{`"other", "abc123"`, true},     // comma-separated, second matches
-		{` "abc123" `, true},            // leading/trailing whitespace
-		{`*`, true},                     // wildcard matches anything
-		{`"abc"`, false},                // different etag
-		{`"abc123x"`, false},            // substring shouldn't match
-		{``, false},                     // empty
-		{`abc123`, false},               // unquoted — invalid per RFC, must not match
+		{etag, true},                // exact match — what browsers send
+		{`W/"abc123"`, true},        // weak validator
+		{`"other", "abc123"`, true}, // comma-separated, second matches
+		{` "abc123" `, true},        // leading/trailing whitespace
+		{`*`, true},                 // wildcard matches anything
+		{`"abc"`, false},            // different etag
+		{`"abc123x"`, false},        // substring shouldn't match
+		{``, false},                 // empty
+		{`abc123`, false},           // unquoted — invalid per RFC, must not match
 	}
 	for _, tt := range tbl {
 		t.Run(tt.header, func(t *testing.T) {

--- a/avatar/localfs.go
+++ b/avatar/localfs.go
@@ -71,7 +71,7 @@ func (fs *LocalFS) Get(avatar string) (reader io.ReadCloser, size int, err error
 func (fs *LocalFS) ID(avatar string) (id string) {
 	location := fs.location(strings.TrimSuffix(avatar, imgSfx))
 	avFile := path.Join(location, avatar)
-	fi, err := os.Stat(avFile)
+	fi, err := os.Stat(avFile) //nolint:gosec // avatar id is store-generated and validated by the proxy handler
 	if err != nil {
 		return encodeID(avatar)
 	}

--- a/provider/apple.go
+++ b/provider/apple.go
@@ -288,7 +288,7 @@ func (ah *AppleHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	ah.Logf("[DEBUG] login url %s, claims=%+v", loginURL, claims)
 
-	http.Redirect(w, r, loginURL, http.StatusFound)
+	http.Redirect(w, r, loginURL, http.StatusFound) //nolint:gosec // redirect goes to the fixed apple auth endpoint, request path only affects redirect_uri query param
 }
 
 // AuthHandler fills user info and redirects to "from" url. This is callback url redirected locally by browser

--- a/provider/custom_server.go
+++ b/provider/custom_server.go
@@ -193,7 +193,8 @@ func (c *CustomServer) handleAvatar(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	if _, err = w.Write(b); err != nil {
+	w.Header().Set("Content-Type", "image/png")
+	if _, err = w.Write(b); err != nil { //nolint:gosec // generated identicon png, not reflected markup
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/provider/dev_provider.go
+++ b/provider/dev_provider.go
@@ -130,7 +130,8 @@ func (d *DevAuthServer) Run(ctx context.Context) { // nolint (gocyclo)
 					w.WriteHeader(http.StatusNotFound)
 					return
 				}
-				if _, err = w.Write(b); err != nil {
+				w.Header().Set("Content-Type", "image/png")
+				if _, err = w.Write(b); err != nil { //nolint:gosec // generated identicon png, not reflected markup
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -171,7 +171,7 @@ func NewTwitter(p Params) Oauth1Handler {
 func NewBattlenet(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
 		name: "battlenet",
-		endpoint: oauth2.Endpoint{
+		endpoint: oauth2.Endpoint{ //nolint:gosec // G101 false positive, oauth endpoint urls are not credentials
 			AuthURL:   "https://eu.battle.net/oauth/authorize",
 			TokenURL:  "https://eu.battle.net/oauth/token",
 			AuthStyle: oauth2.AuthStyleInParams,
@@ -241,7 +241,7 @@ func NewPatreon(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
 		name: "patreon",
 		// see https://docs.patreon.com/?shell#oauth
-		endpoint: oauth2.Endpoint{
+		endpoint: oauth2.Endpoint{ //nolint:gosec // G101 false positive, oauth endpoint urls are not credentials
 			AuthURL:   "https://www.patreon.com/oauth2/authorize",
 			TokenURL:  "https://api.patreon.com/oauth2/token",
 			AuthStyle: oauth2.AuthStyleInParams,
@@ -276,7 +276,7 @@ func NewDiscord(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
 		name: "discord",
 		// see https://discord.com/developers/docs/topics/oauth2
-		endpoint: oauth2.Endpoint{
+		endpoint: oauth2.Endpoint{ //nolint:gosec // G101 false positive, oauth endpoint urls are not credentials
 			AuthURL:  "https://discord.com/oauth2/authorize",
 			TokenURL: "https://discord.com/api/oauth2/token",
 		},

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -260,11 +260,11 @@ func (j *Service) Set(w http.ResponseWriter, claims Claims) (Claims, error) {
 		cookieExpiration = int(j.CookieDuration.Seconds())
 	}
 
-	jwtCookie := http.Cookie{Name: j.JWTCookieName, Value: tokenString, HttpOnly: true, Path: "/", Domain: j.JWTCookieDomain,
+	jwtCookie := http.Cookie{Name: j.JWTCookieName, Value: tokenString, HttpOnly: true, Path: "/", Domain: j.JWTCookieDomain, //nolint:gosec // Secure and SameSite come from service config
 		MaxAge: cookieExpiration, Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &jwtCookie)
 
-	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: claims.Id, HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain,
+	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: claims.Id, HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain, //nolint:gosec // HttpOnly false by design, JS reads it for the X-XSRF-Token header
 		MaxAge: cookieExpiration, Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &xsrfCookie)
 
@@ -335,11 +335,11 @@ func (j *Service) IsExpired(claims Claims) bool {
 
 // Reset token's cookies
 func (j *Service) Reset(w http.ResponseWriter) {
-	jwtCookie := http.Cookie{Name: j.JWTCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain,
+	jwtCookie := http.Cookie{Name: j.JWTCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain, //nolint:gosec // expired removal cookie, carries no value
 		MaxAge: -1, Expires: time.Unix(0, 0), Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &jwtCookie)
 
-	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain,
+	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain, //nolint:gosec // expired removal cookie, carries no value
 		MaxAge: -1, Expires: time.Unix(0, 0), Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &xsrfCookie)
 

--- a/v2/avatar/avatar_test.go
+++ b/v2/avatar/avatar_test.go
@@ -543,15 +543,15 @@ func TestEtagMatches(t *testing.T) {
 		header string
 		want   bool
 	}{
-		{etag, true},                   // exact match — what browsers send
-		{`W/"abc123"`, true},            // weak validator
-		{`"other", "abc123"`, true},     // comma-separated, second matches
-		{` "abc123" `, true},            // leading/trailing whitespace
-		{`*`, true},                     // wildcard matches anything
-		{`"abc"`, false},                // different etag
-		{`"abc123x"`, false},            // substring shouldn't match
-		{``, false},                     // empty
-		{`abc123`, false},               // unquoted — invalid per RFC, must not match
+		{etag, true},                // exact match — what browsers send
+		{`W/"abc123"`, true},        // weak validator
+		{`"other", "abc123"`, true}, // comma-separated, second matches
+		{` "abc123" `, true},        // leading/trailing whitespace
+		{`*`, true},                 // wildcard matches anything
+		{`"abc"`, false},            // different etag
+		{`"abc123x"`, false},        // substring shouldn't match
+		{``, false},                 // empty
+		{`abc123`, false},           // unquoted — invalid per RFC, must not match
 	}
 	for _, tt := range tbl {
 		t.Run(tt.header, func(t *testing.T) {

--- a/v2/avatar/localfs.go
+++ b/v2/avatar/localfs.go
@@ -72,7 +72,7 @@ func (fs *LocalFS) Get(avatar string) (reader io.ReadCloser, size int, err error
 func (fs *LocalFS) ID(avatar string) (id string) {
 	location := fs.location(strings.TrimSuffix(avatar, imgSfx))
 	avFile := path.Join(location, avatar)
-	fi, err := os.Stat(avFile)
+	fi, err := os.Stat(avFile) //nolint:gosec // avatar id is store-generated and validated by the proxy handler
 	if err != nil {
 		return encodeID(avatar)
 	}

--- a/v2/provider/apple.go
+++ b/v2/provider/apple.go
@@ -288,7 +288,7 @@ func (ah *AppleHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	ah.Logf("[DEBUG] login url %s, claims=%+v", loginURL, claims)
 
-	http.Redirect(w, r, loginURL, http.StatusFound)
+	http.Redirect(w, r, loginURL, http.StatusFound) //nolint:gosec // redirect goes to the fixed apple auth endpoint, request path only affects redirect_uri query param
 }
 
 // AuthHandler fills user info and redirects to "from" url. This is callback url redirected locally by browser

--- a/v2/provider/custom_server.go
+++ b/v2/provider/custom_server.go
@@ -193,7 +193,8 @@ func (c *CustomServer) handleAvatar(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	if _, err = w.Write(b); err != nil {
+	w.Header().Set("Content-Type", "image/png")
+	if _, err = w.Write(b); err != nil { //nolint:gosec // generated identicon png, not reflected markup
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/v2/provider/dev_provider.go
+++ b/v2/provider/dev_provider.go
@@ -130,7 +130,8 @@ func (d *DevAuthServer) Run(ctx context.Context) { // nolint (gocyclo)
 					w.WriteHeader(http.StatusNotFound)
 					return
 				}
-				if _, err = w.Write(b); err != nil {
+				w.Header().Set("Content-Type", "image/png")
+				if _, err = w.Write(b); err != nil { //nolint:gosec // generated identicon png, not reflected markup
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}

--- a/v2/provider/providers.go
+++ b/v2/provider/providers.go
@@ -171,7 +171,7 @@ func NewTwitter(p Params) Oauth1Handler {
 func NewBattlenet(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
 		name: "battlenet",
-		endpoint: oauth2.Endpoint{
+		endpoint: oauth2.Endpoint{ //nolint:gosec // G101 false positive, oauth endpoint urls are not credentials
 			AuthURL:   "https://eu.battle.net/oauth/authorize",
 			TokenURL:  "https://eu.battle.net/oauth/token",
 			AuthStyle: oauth2.AuthStyleInParams,
@@ -241,7 +241,7 @@ func NewPatreon(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
 		name: "patreon",
 		// see https://docs.patreon.com/?shell#oauth
-		endpoint: oauth2.Endpoint{
+		endpoint: oauth2.Endpoint{ //nolint:gosec // G101 false positive, oauth endpoint urls are not credentials
 			AuthURL:   "https://www.patreon.com/oauth2/authorize",
 			TokenURL:  "https://api.patreon.com/oauth2/token",
 			AuthStyle: oauth2.AuthStyleInParams,
@@ -276,7 +276,7 @@ func NewDiscord(p Params) Oauth2Handler {
 	return initOauth2Handler(p, Oauth2Handler{
 		name: "discord",
 		// see https://discord.com/developers/docs/topics/oauth2
-		endpoint: oauth2.Endpoint{
+		endpoint: oauth2.Endpoint{ //nolint:gosec // G101 false positive, oauth endpoint urls are not credentials
 			AuthURL:  "https://discord.com/oauth2/authorize",
 			TokenURL: "https://discord.com/api/oauth2/token",
 		},

--- a/v2/token/jwt.go
+++ b/v2/token/jwt.go
@@ -277,11 +277,11 @@ func (j *Service) Set(w http.ResponseWriter, claims Claims) (Claims, error) {
 		cookieExpiration = int(j.CookieDuration.Seconds())
 	}
 
-	jwtCookie := http.Cookie{Name: j.JWTCookieName, Value: tokenString, HttpOnly: true, Path: "/", Domain: j.JWTCookieDomain,
+	jwtCookie := http.Cookie{Name: j.JWTCookieName, Value: tokenString, HttpOnly: true, Path: "/", Domain: j.JWTCookieDomain, //nolint:gosec // Secure and SameSite come from service config
 		MaxAge: cookieExpiration, Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &jwtCookie)
 
-	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: claims.ID, HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain,
+	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: claims.ID, HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain, //nolint:gosec // HttpOnly false by design, JS reads it for the X-XSRF-Token header
 		MaxAge: cookieExpiration, Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &xsrfCookie)
 
@@ -357,11 +357,11 @@ func (j *Service) IsExpired(claims Claims) bool {
 
 // Reset token's cookies
 func (j *Service) Reset(w http.ResponseWriter) {
-	jwtCookie := http.Cookie{Name: j.JWTCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain,
+	jwtCookie := http.Cookie{Name: j.JWTCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain, //nolint:gosec // expired removal cookie, carries no value
 		MaxAge: -1, Expires: time.Unix(0, 0), Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &jwtCookie)
 
-	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain,
+	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: "", HttpOnly: false, Path: "/", Domain: j.JWTCookieDomain, //nolint:gosec // expired removal cookie, carries no value
 		MaxAge: -1, Expires: time.Unix(0, 0), Secure: j.SecureCookies, SameSite: j.SameSite}
 	http.SetCookie(w, &xsrfCookie)
 


### PR DESCRIPTION
CI pinned go 1.24 while all three modules require 1.25 since #297, which made the example build fail on every dependabot PR until toolchain auto-download kicked in, and golangci-lint v2.6.2 panics on the go 1.26 stdlib.

Changes:

- CI: go 1.24 → 1.26, `golangci-lint` v2.6.2 → v2.12.2, `golangci-lint-action` v7 → v9 (v8/v9 have no breaking config changes, node runtime only), `--config=` form for args
- push triggers: explicit `branches: ["**"]` / `tags: ["**"]` instead of empty keys flagged by actionlint
- remaining actions to current majors: `checkout` v4 → v7, `codeql-action` v3 (deprecated) → v4; quoted `$GITHUB_WORKSPACE` in run scripts, actionlint now fully clean (`start-mongoDB@v0.2` is already latest)
- gosec findings new in v2.12, both v1 and v2 modules:
  - dev/test avatar endpoints (`dev_provider.go`, `custom_server.go`) now set `Content-Type: image/png` before writing the generated identicon
  - false positives suppressed with reasons: `token/jwt.go` cookies (Secure/SameSite come from service config, XSRF cookie is JS-readable by design), `provider/providers.go` oauth endpoint urls flagged as hardcoded credentials (G101), `provider/apple.go` redirect to the fixed apple auth endpoint (G710), `avatar/localfs.go` store-generated paths (G703)
  - gosec excluded in `_test.go` files via `.golangci.yml`
- gofmt on `avatar/avatar_test.go` (pre-existing comment alignment drift)

Both modules lint clean with v2.12.2, tests pass with `-race`, example builds. `go fix ./...` produced no changes.
