### PR TITLE
feat: opt-in github numeric user id, reject non-2xx user info

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,18 @@ The tenant value can be a tenant ID (GUID), domain name, or one of the well-know
 1.  Under **"Authorization callback URL"** enter the correct url constructed as domain + `/auth/github/callback`. ie `https://example.mysite.com/auth/github/callback`
 1.  Take note of the **Client ID** and **Client Secret**
 
+##### Username-as-identity caveat
+
+By default the GitHub provider derives the local user id from the account login, as `github_<sha1(login)>`. GitHub releases a username as soon as the account is renamed or deleted, and anyone can claim it afterwards. An application that keys its own records on the returned id will treat the next holder of a released username as the original user. This is the same property described in the [email-as-identity caveat](#email-as-identity-caveat) above, with one difference: GitHub returns an immutable numeric account id in the same response, so the provider can key on that instead.
+
+To do so, register the provider with `AddGithubProviderWithNumericID`, or set `GithubNumericID` when building `provider.Params` directly:
+
+```go
+service.AddGithubProviderWithNumericID(os.Getenv("AEXMPL_GITHUB_CID"), os.Getenv("AEXMPL_GITHUB_CSEC"))
+```
+
+This is off by default because it changes the id of every existing GitHub user. On a running deployment the switch is not transparent: comments, roles, blocks and any other records stored under the old id stop matching, and the old ids cannot be translated offline, because a login cannot be recovered from its hash. Turn it on for a new deployment, or migrate the stored ids yourself first. The recommendation in the email-as-identity caveat applies here too, and avoids the problem entirely: map the provider id to an internal immutable id of your own at first login, and key application records on that.
+
 #### Facebook Auth Provider
 
 1.  From https://developers.facebook.com select **"My Apps"** / **"Add a new App"**

--- a/README.md
+++ b/README.md
@@ -749,7 +749,7 @@ To do so, register the provider with `AddGithubProviderWithNumericID`:
 service.AddGithubProviderWithNumericID("<Client ID>", "<Client Secret>")
 ```
 
-To combine it with `UserAttributes`, set `GithubNumericID` when building `provider.Params` directly (filling `URL`, `JwtService: service.TokenService()` and `AvatarSaver: service.AvatarProxy()`) and register the result with `service.AddCustomHandler(provider.NewGithub(p))`.
+To combine it with `UserAttributes`, set `GithubNumericID` when building `provider.Params` directly and register the result with `service.AddCustomHandler(provider.NewGithub(p))`. That handler is registered as-is, so every field the service would normally supply has to be filled in by hand: `URL`, `JwtService: service.TokenService()`, `AvatarSaver: service.AvatarProxy()`, `L`, and `AllowedRedirectHosts` set to the same value passed in `Opts`. Leaving `AllowedRedirectHosts` nil turns off redirect host validation for that provider, so a service that sets it in `Opts` must repeat it here.
 
 The numeric derivation is best-effort: if the `/user` response carries no usable numeric id, the provider keeps the login-derived id and logs a warning rather than failing the login.
 

--- a/README.md
+++ b/README.md
@@ -743,11 +743,15 @@ The tenant value can be a tenant ID (GUID), domain name, or one of the well-know
 
 By default the GitHub provider derives the local user id from the account login, as `github_<sha1(login)>`. GitHub releases a username as soon as the account is renamed or deleted, and anyone can claim it afterwards. An application that keys its own records on the returned id will treat the next holder of a released username as the original user. This is the same property described in the [email-as-identity caveat](#email-as-identity-caveat) above, with one difference: GitHub returns an immutable numeric account id in the same response, so the provider can key on that instead.
 
-To do so, register the provider with `AddGithubProviderWithNumericID`, or set `GithubNumericID` when building `provider.Params` directly:
+To do so, register the provider with `AddGithubProviderWithNumericID`:
 
 ```go
-service.AddGithubProviderWithNumericID(os.Getenv("AEXMPL_GITHUB_CID"), os.Getenv("AEXMPL_GITHUB_CSEC"))
+service.AddGithubProviderWithNumericID("<Client ID>", "<Client Secret>")
 ```
+
+To combine it with `UserAttributes`, set `GithubNumericID` when building `provider.Params` directly (filling `URL`, `JwtService: service.TokenService()` and `AvatarSaver: service.AvatarProxy()`) and register the result with `service.AddCustomHandler(provider.NewGithub(p))`.
+
+The numeric derivation is best-effort: if the `/user` response carries no usable numeric id, the provider keeps the login-derived id and logs a warning rather than failing the login.
 
 This is off by default because it changes the id of every existing GitHub user. On a running deployment the switch is not transparent: comments, roles, blocks and any other records stored under the old id stop matching, and the old ids cannot be translated offline, because a login cannot be recovered from its hash. Turn it on for a new deployment, or migrate the stored ids yourself first. The recommendation in the email-as-identity caveat applies here too, and avoids the problem entirely: map the provider id to an internal immutable id of your own at first login, and key application records on that.
 

--- a/auth.go
+++ b/auth.go
@@ -386,6 +386,8 @@ func (s *Service) AddMicrosoftProvider(cid, csecret, tenant string) {
 // numeric account id instead of the login. Logins are released on rename or account removal and
 // can be claimed by someone else, so an id derived from login may be inherited by the next holder
 // of the name. This changes the id of every existing github user, see README for the migration note.
+// If the response carries no usable numeric id the login-derived id is kept.
+// For advanced configuration (e.g., UserAttributes), construct provider.Params directly.
 func (s *Service) AddGithubProviderWithNumericID(cid, csecret string) {
 	p := provider.Params{
 		URL:                  s.opts.URL,

--- a/auth.go
+++ b/auth.go
@@ -382,6 +382,26 @@ func (s *Service) AddMicrosoftProvider(cid, csecret, tenant string) {
 	s.addProvider(provider.NewMicrosoft(p))
 }
 
+// AddGithubProviderWithNumericID adds github provider deriving the user id from the immutable
+// numeric account id instead of the login. Logins are released on rename or account removal and
+// can be claimed by someone else, so an id derived from login may be inherited by the next holder
+// of the name. This changes the id of every existing github user, see README for the migration note.
+func (s *Service) AddGithubProviderWithNumericID(cid, csecret string) {
+	p := provider.Params{
+		URL:                  s.opts.URL,
+		JwtService:           s.jwtService,
+		Issuer:               s.issuer,
+		AvatarSaver:          s.avatarProxy,
+		Cid:                  cid,
+		Csecret:              csecret,
+		L:                    s.logger,
+		UserAttributes:       map[string]string{},
+		GithubNumericID:      true,
+		AllowedRedirectHosts: s.opts.AllowedRedirectHosts,
+	}
+	s.addProvider(provider.NewGithub(p))
+}
+
 // AddDevProvider with a custom host and port
 func (s *Service) AddDevProvider(host string, port int) {
 	p := provider.Params{

--- a/auth_test.go
+++ b/auth_test.go
@@ -117,6 +117,34 @@ func TestService_AddMicrosoftProvider(t *testing.T) {
 	})
 }
 
+func TestService_AddGithubProviderWithNumericID(t *testing.T) {
+	options := Opts{
+		SecretReader: token.SecretFunc(func(string) (string, error) { return "secret", nil }),
+		URL:          "http://127.0.0.1:8089",
+		Logger:       logger.Std,
+	}
+
+	t.Run("numeric id enabled", func(t *testing.T) {
+		svc := NewService(options)
+		svc.AddGithubProviderWithNumericID("cid", "csecret")
+		p, err := svc.Provider("github")
+		assert.NoError(t, err)
+		op := p.Provider.(provider.Oauth2Handler)
+		assert.Equal(t, "github", op.Name())
+		assert.True(t, op.GithubNumericID)
+	})
+
+	t.Run("default registration keeps login-based id", func(t *testing.T) {
+		svc := NewService(options)
+		svc.AddProvider("github", "cid", "csecret")
+		p, err := svc.Provider("github")
+		assert.NoError(t, err)
+		op := p.Provider.(provider.Oauth2Handler)
+		assert.Equal(t, "github", op.Name())
+		assert.False(t, op.GithubNumericID)
+	})
+}
+
 func TestService_AddVerifProvider_UsesCustomConfirmationStore(t *testing.T) {
 	custom := &countingVerifStore{}
 	svc := NewService(Opts{

--- a/provider/oauth1.go
+++ b/provider/oauth1.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -115,6 +116,13 @@ func (h Oauth1Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 			h.Logf("[WARN] failed to close response body, %s", e)
 		}
 	}()
+
+	// an error body carries no identity fields, mapping it would hash empty values into a shared id
+	if uinfo.StatusCode < http.StatusOK || uinfo.StatusCode >= http.StatusMultipleChoices {
+		rest.SendErrorJSON(w, r, h.L, http.StatusServiceUnavailable,
+			fmt.Errorf("status %s", uinfo.Status), "failed to get user info")
+		return
+	}
 
 	data, err := io.ReadAll(uinfo.Body)
 	if err != nil {

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -54,6 +54,12 @@ type Params struct {
 	Host string // relevant for providers supporting host customization, for example dev oauth2
 
 	MicrosoftTenant string // tenant for microsoft provider, default "common"
+
+	// GithubNumericID makes github provider derive the user id from the immutable numeric account id
+	// instead of the login. Logins are released on rename or account removal and can be claimed by
+	// someone else, so an id derived from login may be inherited by the next holder of the name.
+	// Enabling this changes the id of every existing github user, see README for the migration note.
+	GithubNumericID bool
 }
 
 // UserData is type for user information returned from oauth2 providers /info API method

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -198,6 +198,13 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	// an error body carries no identity fields, mapping it would hash empty values into a shared id
+	if uinfo.StatusCode < http.StatusOK || uinfo.StatusCode >= http.StatusMultipleChoices {
+		rest.SendErrorJSON(w, r, p.L, http.StatusServiceUnavailable,
+			fmt.Errorf("status %s", uinfo.Status), "failed to get user info")
+		return
+	}
+
 	data, err := io.ReadAll(uinfo.Body)
 	if err != nil {
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "failed to read user info")

--- a/provider/oauth2.go
+++ b/provider/oauth2.go
@@ -59,6 +59,7 @@ type Params struct {
 	// instead of the login. Logins are released on rename or account removal and can be claimed by
 	// someone else, so an id derived from login may be inherited by the next holder of the name.
 	// Enabling this changes the id of every existing github user, see README for the migration note.
+	// Best-effort: if the response carries no usable numeric id the login-derived id is kept.
 	GithubNumericID bool
 }
 

--- a/provider/oauth2_test.go
+++ b/provider/oauth2_test.go
@@ -368,6 +368,77 @@ func TestMakeRedirURL(t *testing.T) {
 	}
 }
 
+func TestOauth2LoginRejectsFailedUserInfo(t *testing.T) {
+	// a non-2xx user info response carries no identity fields, mapping it would sign everyone
+	// in under the same empty-value id
+	loginPort, authPort := 8995, 8996
+	prov := Oauth2Handler{
+		name: "mock",
+		endpoint: oauth2.Endpoint{
+			AuthURL:  fmt.Sprintf("http://localhost:%d/login/oauth/authorize", authPort),
+			TokenURL: fmt.Sprintf("http://localhost:%d/login/oauth/access_token", authPort),
+		},
+		scopes:  []string{"user:email"},
+		infoURL: fmt.Sprintf("http://localhost:%d/user", authPort),
+		mapUser: func(data UserData, _ []byte) token.User {
+			return token.User{ID: "mock_" + data.Value("id"), Name: data.Value("name")}
+		},
+	}
+
+	jwtService := token.NewService(token.Opts{SecretReader: token.SecretFunc(mockKeyStore), SecureCookies: false,
+		TokenDuration: time.Hour, CookieDuration: days31})
+	prov = initOauth2Handler(Params{URL: "url", Cid: "cid", Csecret: "csecret", JwtService: jwtService,
+		Issuer: "remark42", AvatarSaver: &mockAvatarSaver{}, L: logger.Std}, prov)
+	svc := Service{Provider: prov}
+
+	ts := &http.Server{Addr: fmt.Sprintf(":%d", loginPort), Handler: http.HandlerFunc(svc.Handler)} //nolint:gosec
+	oauth := &http.Server{                                                                          //nolint:gosec
+		Addr: fmt.Sprintf(":%d", authPort),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/login/oauth/authorize"):
+				w.Header().Add("Location", fmt.Sprintf("http://localhost:%d/callback?code=g0ZGZmNjVmOWI&state=%s",
+					loginPort, r.URL.Query().Get("state")))
+				w.WriteHeader(302)
+			case strings.HasPrefix(r.URL.Path, "/login/oauth/access_token"):
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				_, err := w.Write([]byte(`{"access_token":"MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3","token_type":"bearer"}`))
+				assert.NoError(t, err)
+			case strings.HasPrefix(r.URL.Path, "/user"):
+				// revoked token, rate limit or outage: valid json, no identity fields
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, err := w.Write([]byte(`{"message":"Bad credentials"}`))
+				assert.NoError(t, err)
+			default:
+				t.Fatalf("unexpected oauth request %s %s", r.Method, r.URL)
+			}
+		}),
+	}
+
+	go func() { _ = oauth.ListenAndServe() }()
+	go func() { _ = ts.ListenAndServe() }()
+	time.Sleep(time.Millisecond * 100) // let them start
+	defer func() {
+		assert.NoError(t, ts.Close())
+		assert.NoError(t, oauth.Close())
+	}()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client := &http.Client{Jar: jar, Timeout: 5 * time.Second}
+
+	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/login?site=remark", loginPort))
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, resp.Body.Close()) }()
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "login must fail, got body %s", string(body))
+	assert.NotContains(t, string(body), "mock_", "no user may be mapped from a failed user info response")
+	assert.Empty(t, resp.Cookies(), "no auth cookie on failed login")
+}
+
 func prepOauth2Test(t *testing.T, loginPort, authPort int, btHook BearerTokenHook, paramOpts ...func(*Params)) func() {
 
 	provider := Oauth2Handler{

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1" //nolint
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/dghubble/oauth1"
@@ -53,11 +54,21 @@ func NewGithub(p Params) Oauth2Handler {
 		endpoint: github.Endpoint,
 		scopes:   []string{},
 		infoURL:  "https://api.github.com/user",
-		mapUser: func(data UserData, _ []byte) token.User {
+		mapUser: func(data UserData, bdata []byte) token.User {
 			userInfo := token.User{
 				ID:      "github_" + token.HashID(sha1.New(), data.Value("login")),
 				Name:    data.Value("name"),
 				Picture: data.Value("avatar_url"),
+			}
+			if p.GithubNumericID {
+				// data.Value is not usable here, json numbers decode to float64 and format as "1.345027e+06".
+				// on a missing or unparsable id keep the login-based value, it is still unique per account
+				var uinfoJSON struct {
+					ID int64 `json:"id"`
+				}
+				if err := json.Unmarshal(bdata, &uinfoJSON); err == nil && uinfoJSON.ID != 0 {
+					userInfo.ID = "github_" + token.HashID(sha1.New(), strconv.FormatInt(uinfoJSON.ID, 10))
+				}
 			}
 			// github may have no user name, use login in this case
 			if userInfo.Name == "" {

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dghubble/oauth1"
 	"github.com/dghubble/oauth1/twitter"
+	"github.com/go-pkgz/auth/logger"
 	"github.com/go-pkgz/auth/token"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/facebook"
@@ -49,6 +50,9 @@ func NewGoogle(p Params) Oauth2Handler {
 
 // NewGithub makes github oauth2 provider
 func NewGithub(p Params) Oauth2Handler {
+	if p.L == nil {
+		p.L = logger.NoOp // mapUser below captures p, initOauth2Handler defaults its own copy only
+	}
 	return initOauth2Handler(p, Oauth2Handler{
 		name:     "github",
 		endpoint: github.Endpoint,
@@ -62,12 +66,15 @@ func NewGithub(p Params) Oauth2Handler {
 			}
 			if p.GithubNumericID {
 				// data.Value is not usable here, json numbers decode to float64 and format as "1.345027e+06".
-				// on a missing or unparsable id keep the login-based value, it is still unique per account
+				// the "gid:" prefix keeps numeric ids out of the login hash space, logins may be all-digit
 				var uinfoJSON struct {
 					ID int64 `json:"id"`
 				}
 				if err := json.Unmarshal(bdata, &uinfoJSON); err == nil && uinfoJSON.ID != 0 {
-					userInfo.ID = "github_" + token.HashID(sha1.New(), strconv.FormatInt(uinfoJSON.ID, 10))
+					userInfo.ID = "github_" + token.HashID(sha1.New(), "gid:"+strconv.FormatInt(uinfoJSON.ID, 10))
+				} else {
+					// keep the login-based value, matching the default derivation and its recycling caveat
+					p.Logf("[WARN] github numeric id not available, keeping login-based id")
 				}
 			}
 			// github may have no user name, use login in this case

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -58,12 +58,12 @@ func TestProviders_NewGithub(t *testing.T) {
 	})
 
 	t.Run("with extra scopes", func(t *testing.T) {
-		r := NewGithub(Params{URL: "http://demo.remark42.com", Cid: "cid", Csecret: "cs",
+		withAttrs := NewGithub(Params{URL: "http://demo.remark42.com", Cid: "cid", Csecret: "cs",
 			UserAttributes: map[string]string{"email": "email"}})
-		assert.Equal(t, "github", r.Name())
+		assert.Equal(t, "github", withAttrs.Name())
 		udata := UserData{"login": "lll", "name": "test user", "avatar_url": "http://demo.remark42.com/blah.png",
 			"email": "test@email.com"}
-		user := r.mapUser(udata, nil)
+		user := withAttrs.mapUser(udata, nil)
 		assert.Equal(t, token.User{Name: "test user", ID: "github_e80b2d2608711cbb3312db7c4727a46fbad9601a",
 			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}}, user, "got %+v", user)
 	})

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -67,6 +67,46 @@ func TestProviders_NewGithub(t *testing.T) {
 		assert.Equal(t, token.User{Name: "test user", ID: "github_e80b2d2608711cbb3312db7c4727a46fbad9601a",
 			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}}, user, "got %+v", user)
 	})
+
+	t.Run("numeric id ignored by default", func(t *testing.T) {
+		udata := UserData{"login": "lll", "name": "test user", "avatar_url": "http://demo.remark42.com/blah.png"}
+		user := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
+		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", user.ID, "login-based id kept")
+	})
+}
+
+func TestProviders_NewGithubNumericID(t *testing.T) {
+	r := NewGithub(Params{URL: "http://demo.remark42.com", Cid: "cid", Csecret: "cs", GithubNumericID: true})
+	assert.Equal(t, "github", r.Name())
+
+	t.Run("id from numeric account id", func(t *testing.T) {
+		udata := UserData{"login": "lll", "name": "test user", "avatar_url": "http://demo.remark42.com/blah.png"}
+		user := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
+		assert.Equal(t, token.User{Name: "test user", ID: "github_8fe01ac1fd7d3d54465163865d19dea8d7476704",
+			Picture: "http://demo.remark42.com/blah.png", IP: ""}, user, "got %+v", user)
+	})
+
+	t.Run("recycled login maps to different users", func(t *testing.T) {
+		udata := UserData{"login": "lll", "name": "test user"}
+		victim := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
+		attacker := r.mapUser(udata, []byte(`{"id": 219851832, "login": "lll"}`))
+		assert.Equal(t, "github_8fe01ac1fd7d3d54465163865d19dea8d7476704", victim.ID)
+		assert.Equal(t, "github_84b819bbdad1aa54c7158a7dce83edf87cadc23e", attacker.ID)
+		assert.NotEqual(t, victim.ID, attacker.ID, "same login with different accounts must not collide")
+	})
+
+	t.Run("renamed account keeps the same id", func(t *testing.T) {
+		before := r.mapUser(UserData{"login": "lll"}, []byte(`{"id": 1345027, "login": "lll"}`))
+		after := r.mapUser(UserData{"login": "renamed"}, []byte(`{"id": 1345027, "login": "renamed"}`))
+		assert.Equal(t, before.ID, after.ID, "rename must not change the id")
+	})
+
+	t.Run("falls back to login without numeric id", func(t *testing.T) {
+		udata := UserData{"login": "lll", "name": "test user"}
+		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, nil).ID, "nil body")
+		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, []byte(`{"login": "lll"}`)).ID, "no id field")
+		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, []byte(`{"id": 0}`)).ID, "zero id")
+	})
 }
 
 func TestProviders_NewFacebook(t *testing.T) {

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -82,7 +82,7 @@ func TestProviders_NewGithubNumericID(t *testing.T) {
 	t.Run("id from numeric account id", func(t *testing.T) {
 		udata := UserData{"login": "lll", "name": "test user", "avatar_url": "http://demo.remark42.com/blah.png"}
 		user := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
-		assert.Equal(t, token.User{Name: "test user", ID: "github_8fe01ac1fd7d3d54465163865d19dea8d7476704",
+		assert.Equal(t, token.User{Name: "test user", ID: "github_d4dc5da9a1e6bbd5d77920e4ea2ca91707e59083",
 			Picture: "http://demo.remark42.com/blah.png", IP: ""}, user, "got %+v", user)
 	})
 
@@ -90,8 +90,8 @@ func TestProviders_NewGithubNumericID(t *testing.T) {
 		udata := UserData{"login": "lll", "name": "test user"}
 		victim := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
 		attacker := r.mapUser(udata, []byte(`{"id": 219851832, "login": "lll"}`))
-		assert.Equal(t, "github_8fe01ac1fd7d3d54465163865d19dea8d7476704", victim.ID)
-		assert.Equal(t, "github_84b819bbdad1aa54c7158a7dce83edf87cadc23e", attacker.ID)
+		assert.Equal(t, "github_d4dc5da9a1e6bbd5d77920e4ea2ca91707e59083", victim.ID)
+		assert.Equal(t, "github_d7f2f255cff0e923394424ee9038da06a4a12e89", attacker.ID)
 		assert.NotEqual(t, victim.ID, attacker.ID, "same login with different accounts must not collide")
 	})
 
@@ -101,7 +101,17 @@ func TestProviders_NewGithubNumericID(t *testing.T) {
 		assert.Equal(t, before.ID, after.ID, "rename must not change the id")
 	})
 
-	t.Run("falls back to login without numeric id", func(t *testing.T) {
+	t.Run("all-digit login does not collide with a numeric id", func(t *testing.T) {
+		// github allows all-digit logins, so login "27385" and account id 27385 are different real users
+		def := NewGithub(Params{URL: "http://demo.remark42.com", Cid: "cid", Csecret: "cs"})
+		byLogin := def.mapUser(UserData{"login": "27385"}, []byte(`{"id": 11210579, "login": "27385"}`))
+		byNumeric := r.mapUser(UserData{"login": "1234"}, []byte(`{"id": 27385, "login": "1234"}`))
+		assert.Equal(t, "github_f862a2565f61de2e7ebf5afed09fbe2e05bc9e8d", byLogin.ID)
+		assert.Equal(t, "github_5b067825dfd5af0c41d1c1f6f16aad3ff3397473", byNumeric.ID)
+		assert.NotEqual(t, byLogin.ID, byNumeric.ID, "login and numeric id spaces must not overlap")
+	})
+
+	t.Run("falls back to login without a usable numeric id", func(t *testing.T) {
 		udata := UserData{"login": "lll", "name": "test user"}
 		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, nil).ID, "nil body")
 		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, []byte(`{"login": "lll"}`)).ID, "no id field")

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -383,6 +383,26 @@ func (s *Service) AddMicrosoftProvider(cid, csecret, tenant string) {
 	s.addProvider(provider.NewMicrosoft(p))
 }
 
+// AddGithubProviderWithNumericID adds github provider deriving the user id from the immutable
+// numeric account id instead of the login. Logins are released on rename or account removal and
+// can be claimed by someone else, so an id derived from login may be inherited by the next holder
+// of the name. This changes the id of every existing github user, see README for the migration note.
+func (s *Service) AddGithubProviderWithNumericID(cid, csecret string) {
+	p := provider.Params{
+		URL:                  s.opts.URL,
+		JwtService:           s.jwtService,
+		Issuer:               s.issuer,
+		AvatarSaver:          s.avatarProxy,
+		Cid:                  cid,
+		Csecret:              csecret,
+		L:                    s.logger,
+		UserAttributes:       map[string]string{},
+		GithubNumericID:      true,
+		AllowedRedirectHosts: s.opts.AllowedRedirectHosts,
+	}
+	s.addProvider(provider.NewGithub(p))
+}
+
 // AddDevProvider with a custom host and port
 func (s *Service) AddDevProvider(host string, port int) {
 	p := provider.Params{

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -387,6 +387,8 @@ func (s *Service) AddMicrosoftProvider(cid, csecret, tenant string) {
 // numeric account id instead of the login. Logins are released on rename or account removal and
 // can be claimed by someone else, so an id derived from login may be inherited by the next holder
 // of the name. This changes the id of every existing github user, see README for the migration note.
+// If the response carries no usable numeric id the login-derived id is kept.
+// For advanced configuration (e.g., UserAttributes), construct provider.Params directly.
 func (s *Service) AddGithubProviderWithNumericID(cid, csecret string) {
 	p := provider.Params{
 		URL:                  s.opts.URL,

--- a/v2/auth_test.go
+++ b/v2/auth_test.go
@@ -117,6 +117,34 @@ func TestService_AddMicrosoftProvider(t *testing.T) {
 	})
 }
 
+func TestService_AddGithubProviderWithNumericID(t *testing.T) {
+	options := Opts{
+		SecretReader: token.SecretFunc(func(string) (string, error) { return "secret", nil }),
+		URL:          "http://127.0.0.1:8089",
+		Logger:       logger.Std,
+	}
+
+	t.Run("numeric id enabled", func(t *testing.T) {
+		svc := NewService(options)
+		svc.AddGithubProviderWithNumericID("cid", "csecret")
+		p, err := svc.Provider("github")
+		assert.NoError(t, err)
+		op := p.Provider.(provider.Oauth2Handler)
+		assert.Equal(t, "github", op.Name())
+		assert.True(t, op.GithubNumericID)
+	})
+
+	t.Run("default registration keeps login-based id", func(t *testing.T) {
+		svc := NewService(options)
+		svc.AddProvider("github", "cid", "csecret")
+		p, err := svc.Provider("github")
+		assert.NoError(t, err)
+		op := p.Provider.(provider.Oauth2Handler)
+		assert.Equal(t, "github", op.Name())
+		assert.False(t, op.GithubNumericID)
+	})
+}
+
 func TestService_AddVerifProvider_UsesCustomConfirmationStore(t *testing.T) {
 	custom := &countingVerifStore{}
 	svc := NewService(Opts{

--- a/v2/provider/oauth1.go
+++ b/v2/provider/oauth1.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -115,6 +116,13 @@ func (h Oauth1Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 			h.Logf("[WARN] failed to close response body, %s", e)
 		}
 	}()
+
+	// an error body carries no identity fields, mapping it would hash empty values into a shared id
+	if uinfo.StatusCode < http.StatusOK || uinfo.StatusCode >= http.StatusMultipleChoices {
+		rest.SendErrorJSON(w, r, h.L, http.StatusServiceUnavailable,
+			fmt.Errorf("status %s", uinfo.Status), "failed to get user info")
+		return
+	}
 
 	data, err := io.ReadAll(uinfo.Body)
 	if err != nil {

--- a/v2/provider/oauth2.go
+++ b/v2/provider/oauth2.go
@@ -54,6 +54,12 @@ type Params struct {
 	Host string // relevant for providers supporting host customization, for example dev oauth2
 
 	MicrosoftTenant string // tenant for microsoft provider, default "common"
+
+	// GithubNumericID makes github provider derive the user id from the immutable numeric account id
+	// instead of the login. Logins are released on rename or account removal and can be claimed by
+	// someone else, so an id derived from login may be inherited by the next holder of the name.
+	// Enabling this changes the id of every existing github user, see README for the migration note.
+	GithubNumericID bool
 }
 
 // UserData is type for user information returned from oauth2 providers /info API method

--- a/v2/provider/oauth2.go
+++ b/v2/provider/oauth2.go
@@ -198,6 +198,13 @@ func (p Oauth2Handler) AuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	// an error body carries no identity fields, mapping it would hash empty values into a shared id
+	if uinfo.StatusCode < http.StatusOK || uinfo.StatusCode >= http.StatusMultipleChoices {
+		rest.SendErrorJSON(w, r, p.L, http.StatusServiceUnavailable,
+			fmt.Errorf("status %s", uinfo.Status), "failed to get user info")
+		return
+	}
+
 	data, err := io.ReadAll(uinfo.Body)
 	if err != nil {
 		rest.SendErrorJSON(w, r, p.L, http.StatusInternalServerError, err, "failed to read user info")

--- a/v2/provider/oauth2.go
+++ b/v2/provider/oauth2.go
@@ -59,6 +59,7 @@ type Params struct {
 	// instead of the login. Logins are released on rename or account removal and can be claimed by
 	// someone else, so an id derived from login may be inherited by the next holder of the name.
 	// Enabling this changes the id of every existing github user, see README for the migration note.
+	// Best-effort: if the response carries no usable numeric id the login-derived id is kept.
 	GithubNumericID bool
 }
 

--- a/v2/provider/oauth2_test.go
+++ b/v2/provider/oauth2_test.go
@@ -377,6 +377,77 @@ func TestMakeRedirURL(t *testing.T) {
 	}
 }
 
+func TestOauth2LoginRejectsFailedUserInfo(t *testing.T) {
+	// a non-2xx user info response carries no identity fields, mapping it would sign everyone
+	// in under the same empty-value id
+	loginPort, authPort := 8995, 8996
+	prov := Oauth2Handler{
+		name: "mock",
+		endpoint: oauth2.Endpoint{
+			AuthURL:  fmt.Sprintf("http://localhost:%d/login/oauth/authorize", authPort),
+			TokenURL: fmt.Sprintf("http://localhost:%d/login/oauth/access_token", authPort),
+		},
+		scopes:  []string{"user:email"},
+		infoURL: fmt.Sprintf("http://localhost:%d/user", authPort),
+		mapUser: func(data UserData, _ []byte) token.User {
+			return token.User{ID: "mock_" + data.Value("id"), Name: data.Value("name")}
+		},
+	}
+
+	jwtService := token.NewService(token.Opts{SecretReader: token.SecretFunc(mockKeyStore), SecureCookies: false,
+		TokenDuration: time.Hour, CookieDuration: days31})
+	prov = initOauth2Handler(Params{URL: "url", Cid: "cid", Csecret: "csecret", JwtService: jwtService,
+		Issuer: "remark42", AvatarSaver: &mockAvatarSaver{}, L: logger.Std}, prov)
+	svc := Service{Provider: prov}
+
+	ts := &http.Server{Addr: fmt.Sprintf(":%d", loginPort), Handler: http.HandlerFunc(svc.Handler)} //nolint:gosec
+	oauth := &http.Server{                                                                          //nolint:gosec
+		Addr: fmt.Sprintf(":%d", authPort),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/login/oauth/authorize"):
+				w.Header().Add("Location", fmt.Sprintf("http://localhost:%d/callback?code=g0ZGZmNjVmOWI&state=%s",
+					loginPort, r.URL.Query().Get("state")))
+				w.WriteHeader(302)
+			case strings.HasPrefix(r.URL.Path, "/login/oauth/access_token"):
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				_, err := w.Write([]byte(`{"access_token":"MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3","token_type":"bearer"}`))
+				assert.NoError(t, err)
+			case strings.HasPrefix(r.URL.Path, "/user"):
+				// revoked token, rate limit or outage: valid json, no identity fields
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, err := w.Write([]byte(`{"message":"Bad credentials"}`))
+				assert.NoError(t, err)
+			default:
+				t.Fatalf("unexpected oauth request %s %s", r.Method, r.URL)
+			}
+		}),
+	}
+
+	go func() { _ = oauth.ListenAndServe() }()
+	go func() { _ = ts.ListenAndServe() }()
+	time.Sleep(time.Millisecond * 100) // let them start
+	defer func() {
+		assert.NoError(t, ts.Close())
+		assert.NoError(t, oauth.Close())
+	}()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client := &http.Client{Jar: jar, Timeout: 5 * time.Second}
+
+	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/login?site=remark", loginPort))
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, resp.Body.Close()) }()
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "login must fail, got body %s", string(body))
+	assert.NotContains(t, string(body), "mock_", "no user may be mapped from a failed user info response")
+	assert.Empty(t, resp.Cookies(), "no auth cookie on failed login")
+}
+
 func prepOauth2Test(t *testing.T, loginPort, authPort int, btHook BearerTokenHook, paramOpts ...func(*Params)) func() {
 
 	provider := Oauth2Handler{

--- a/v2/provider/providers.go
+++ b/v2/provider/providers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1" //nolint
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/dghubble/oauth1"
@@ -53,11 +54,21 @@ func NewGithub(p Params) Oauth2Handler {
 		endpoint: github.Endpoint,
 		scopes:   []string{},
 		infoURL:  "https://api.github.com/user",
-		mapUser: func(data UserData, _ []byte) token.User {
+		mapUser: func(data UserData, bdata []byte) token.User {
 			userInfo := token.User{
 				ID:      "github_" + token.HashID(sha1.New(), data.Value("login")),
 				Name:    data.Value("name"),
 				Picture: data.Value("avatar_url"),
+			}
+			if p.GithubNumericID {
+				// data.Value is not usable here, json numbers decode to float64 and format as "1.345027e+06".
+				// on a missing or unparsable id keep the login-based value, it is still unique per account
+				var uinfoJSON struct {
+					ID int64 `json:"id"`
+				}
+				if err := json.Unmarshal(bdata, &uinfoJSON); err == nil && uinfoJSON.ID != 0 {
+					userInfo.ID = "github_" + token.HashID(sha1.New(), strconv.FormatInt(uinfoJSON.ID, 10))
+				}
 			}
 			// github may have no user name, use login in this case
 			if userInfo.Name == "" {

--- a/v2/provider/providers.go
+++ b/v2/provider/providers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dghubble/oauth1"
 	"github.com/dghubble/oauth1/twitter"
+	"github.com/go-pkgz/auth/v2/logger"
 	"github.com/go-pkgz/auth/v2/token"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/facebook"
@@ -49,6 +50,9 @@ func NewGoogle(p Params) Oauth2Handler {
 
 // NewGithub makes github oauth2 provider
 func NewGithub(p Params) Oauth2Handler {
+	if p.L == nil {
+		p.L = logger.NoOp // mapUser below captures p, initOauth2Handler defaults its own copy only
+	}
 	return initOauth2Handler(p, Oauth2Handler{
 		name:     "github",
 		endpoint: github.Endpoint,
@@ -62,12 +66,15 @@ func NewGithub(p Params) Oauth2Handler {
 			}
 			if p.GithubNumericID {
 				// data.Value is not usable here, json numbers decode to float64 and format as "1.345027e+06".
-				// on a missing or unparsable id keep the login-based value, it is still unique per account
+				// the "gid:" prefix keeps numeric ids out of the login hash space, logins may be all-digit
 				var uinfoJSON struct {
 					ID int64 `json:"id"`
 				}
 				if err := json.Unmarshal(bdata, &uinfoJSON); err == nil && uinfoJSON.ID != 0 {
-					userInfo.ID = "github_" + token.HashID(sha1.New(), strconv.FormatInt(uinfoJSON.ID, 10))
+					userInfo.ID = "github_" + token.HashID(sha1.New(), "gid:"+strconv.FormatInt(uinfoJSON.ID, 10))
+				} else {
+					// keep the login-based value, matching the default derivation and its recycling caveat
+					p.Logf("[WARN] github numeric id not available, keeping login-based id")
 				}
 			}
 			// github may have no user name, use login in this case

--- a/v2/provider/providers_test.go
+++ b/v2/provider/providers_test.go
@@ -58,12 +58,12 @@ func TestProviders_NewGithub(t *testing.T) {
 	})
 
 	t.Run("with extra scopes", func(t *testing.T) {
-		r := NewGithub(Params{URL: "http://demo.remark42.com", Cid: "cid", Csecret: "cs",
+		withAttrs := NewGithub(Params{URL: "http://demo.remark42.com", Cid: "cid", Csecret: "cs",
 			UserAttributes: map[string]string{"email": "email"}})
-		assert.Equal(t, "github", r.Name())
+		assert.Equal(t, "github", withAttrs.Name())
 		udata := UserData{"login": "lll", "name": "test user", "avatar_url": "http://demo.remark42.com/blah.png",
 			"email": "test@email.com"}
-		user := r.mapUser(udata, nil)
+		user := withAttrs.mapUser(udata, nil)
 		assert.Equal(t, token.User{Name: "test user", ID: "github_e80b2d2608711cbb3312db7c4727a46fbad9601a",
 			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}}, user, "got %+v", user)
 	})

--- a/v2/provider/providers_test.go
+++ b/v2/provider/providers_test.go
@@ -67,6 +67,46 @@ func TestProviders_NewGithub(t *testing.T) {
 		assert.Equal(t, token.User{Name: "test user", ID: "github_e80b2d2608711cbb3312db7c4727a46fbad9601a",
 			Picture: "http://demo.remark42.com/blah.png", IP: "", Attributes: map[string]any{"email": "test@email.com"}}, user, "got %+v", user)
 	})
+
+	t.Run("numeric id ignored by default", func(t *testing.T) {
+		udata := UserData{"login": "lll", "name": "test user", "avatar_url": "http://demo.remark42.com/blah.png"}
+		user := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
+		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", user.ID, "login-based id kept")
+	})
+}
+
+func TestProviders_NewGithubNumericID(t *testing.T) {
+	r := NewGithub(Params{URL: "http://demo.remark42.com", Cid: "cid", Csecret: "cs", GithubNumericID: true})
+	assert.Equal(t, "github", r.Name())
+
+	t.Run("id from numeric account id", func(t *testing.T) {
+		udata := UserData{"login": "lll", "name": "test user", "avatar_url": "http://demo.remark42.com/blah.png"}
+		user := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
+		assert.Equal(t, token.User{Name: "test user", ID: "github_8fe01ac1fd7d3d54465163865d19dea8d7476704",
+			Picture: "http://demo.remark42.com/blah.png", IP: ""}, user, "got %+v", user)
+	})
+
+	t.Run("recycled login maps to different users", func(t *testing.T) {
+		udata := UserData{"login": "lll", "name": "test user"}
+		victim := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
+		attacker := r.mapUser(udata, []byte(`{"id": 219851832, "login": "lll"}`))
+		assert.Equal(t, "github_8fe01ac1fd7d3d54465163865d19dea8d7476704", victim.ID)
+		assert.Equal(t, "github_84b819bbdad1aa54c7158a7dce83edf87cadc23e", attacker.ID)
+		assert.NotEqual(t, victim.ID, attacker.ID, "same login with different accounts must not collide")
+	})
+
+	t.Run("renamed account keeps the same id", func(t *testing.T) {
+		before := r.mapUser(UserData{"login": "lll"}, []byte(`{"id": 1345027, "login": "lll"}`))
+		after := r.mapUser(UserData{"login": "renamed"}, []byte(`{"id": 1345027, "login": "renamed"}`))
+		assert.Equal(t, before.ID, after.ID, "rename must not change the id")
+	})
+
+	t.Run("falls back to login without numeric id", func(t *testing.T) {
+		udata := UserData{"login": "lll", "name": "test user"}
+		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, nil).ID, "nil body")
+		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, []byte(`{"login": "lll"}`)).ID, "no id field")
+		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, []byte(`{"id": 0}`)).ID, "zero id")
+	})
 }
 
 func TestProviders_NewFacebook(t *testing.T) {

--- a/v2/provider/providers_test.go
+++ b/v2/provider/providers_test.go
@@ -82,7 +82,7 @@ func TestProviders_NewGithubNumericID(t *testing.T) {
 	t.Run("id from numeric account id", func(t *testing.T) {
 		udata := UserData{"login": "lll", "name": "test user", "avatar_url": "http://demo.remark42.com/blah.png"}
 		user := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
-		assert.Equal(t, token.User{Name: "test user", ID: "github_8fe01ac1fd7d3d54465163865d19dea8d7476704",
+		assert.Equal(t, token.User{Name: "test user", ID: "github_d4dc5da9a1e6bbd5d77920e4ea2ca91707e59083",
 			Picture: "http://demo.remark42.com/blah.png", IP: ""}, user, "got %+v", user)
 	})
 
@@ -90,8 +90,8 @@ func TestProviders_NewGithubNumericID(t *testing.T) {
 		udata := UserData{"login": "lll", "name": "test user"}
 		victim := r.mapUser(udata, []byte(`{"id": 1345027, "login": "lll"}`))
 		attacker := r.mapUser(udata, []byte(`{"id": 219851832, "login": "lll"}`))
-		assert.Equal(t, "github_8fe01ac1fd7d3d54465163865d19dea8d7476704", victim.ID)
-		assert.Equal(t, "github_84b819bbdad1aa54c7158a7dce83edf87cadc23e", attacker.ID)
+		assert.Equal(t, "github_d4dc5da9a1e6bbd5d77920e4ea2ca91707e59083", victim.ID)
+		assert.Equal(t, "github_d7f2f255cff0e923394424ee9038da06a4a12e89", attacker.ID)
 		assert.NotEqual(t, victim.ID, attacker.ID, "same login with different accounts must not collide")
 	})
 
@@ -101,7 +101,17 @@ func TestProviders_NewGithubNumericID(t *testing.T) {
 		assert.Equal(t, before.ID, after.ID, "rename must not change the id")
 	})
 
-	t.Run("falls back to login without numeric id", func(t *testing.T) {
+	t.Run("all-digit login does not collide with a numeric id", func(t *testing.T) {
+		// github allows all-digit logins, so login "27385" and account id 27385 are different real users
+		def := NewGithub(Params{URL: "http://demo.remark42.com", Cid: "cid", Csecret: "cs"})
+		byLogin := def.mapUser(UserData{"login": "27385"}, []byte(`{"id": 11210579, "login": "27385"}`))
+		byNumeric := r.mapUser(UserData{"login": "1234"}, []byte(`{"id": 27385, "login": "1234"}`))
+		assert.Equal(t, "github_f862a2565f61de2e7ebf5afed09fbe2e05bc9e8d", byLogin.ID)
+		assert.Equal(t, "github_5b067825dfd5af0c41d1c1f6f16aad3ff3397473", byNumeric.ID)
+		assert.NotEqual(t, byLogin.ID, byNumeric.ID, "login and numeric id spaces must not overlap")
+	})
+
+	t.Run("falls back to login without a usable numeric id", func(t *testing.T) {
 		udata := UserData{"login": "lll", "name": "test user"}
 		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, nil).ID, "nil body")
 		assert.Equal(t, "github_e80b2d2608711cbb3312db7c4727a46fbad9601a", r.mapUser(udata, []byte(`{"login": "lll"}`)).ID, "no id field")


### PR DESCRIPTION
two changes, both applied to v1 and v2.

**opt-in github user id from the numeric account id**

the github provider derives the local user id from the login, `github_<sha1(login)>`. GitHub releases a username on rename or account deletion and anyone can claim it afterwards, so an id derived from login can be inherited by the next holder of the name. Every other oauth2 provider here already keys on an immutable subject: google on `sub`, the rest on `id` or `id_str`.

new `provider.Params.GithubNumericID` and `Service.AddGithubProviderWithNumericID` derive the id from the immutable numeric account id instead. Off by default, because switching the derivation changes the id of every existing github user, and apps that key records, roles or blocks on that id cannot remap them offline. The README documents the caveat and the migration cost.

the hashed input is domain separated with a `gid:` prefix. Without it the two id spaces overlap: github allows all-digit logins, so login `27385` and account id 27385 produce the same local id, and those are two different real accounts.

**reject non-2xx user info responses**

the oauth1 and oauth2 callback handlers checked only the transport error from the user info request, never the HTTP status. An error body carries no identity fields, so `mapUser` hashed empty values and every failed callback produced the same local id, `github_` + sha1("") for github. A revoked token, a rate limit or a provider outage was enough to sign the caller in under that shared identity.

this affects all oauth2 providers and the oauth1 (twitter) path. Apple and telegram already checked their status codes.
